### PR TITLE
限制輸入框高度

### DIFF
--- a/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
+++ b/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
@@ -854,8 +854,9 @@ export default {
 .vac-textarea {
     height: 20px;
     width: 100%;
+    max-height: 50vh;
     line-height: 20px;
-    overflow: hidden;
+    overflow: auto;
     outline: 0;
     resize: none;
     border-radius: 20px;


### PR DESCRIPTION
當輸入文字行數極高的時候，輸入框會佔用大部分以至整個聊天版面。
此pr限制輸入框高度以及允許輸入框內使用滾動條。

調整前:
![test line 1 censored](https://user-images.githubusercontent.com/20432565/158829417-ab449b58-d173-41c8-8046-140c18ceed2d.png)
![test line 2 censored](https://user-images.githubusercontent.com/20432565/158829489-2bc33e4d-c251-4c5a-bbf5-7011c223243e.png)

調整後:
![test line 1 lim censored](https://user-images.githubusercontent.com/20432565/158829649-1d1bf3d6-fa94-4669-b9ba-0e580aa13ab8.png)
![test line 2 lim censored](https://user-images.githubusercontent.com/20432565/158829735-49956a73-1436-495f-827b-28e8642bfed9.png)

