### PR TITLE
fix: ignore keydown event while IME composing

### DIFF
--- a/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
+++ b/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
@@ -439,6 +439,7 @@ export default {
     async mounted() {
         this.newMessages = []
         this.$refs.roomTextarea.addEventListener('keydown', (e) => {
+            if (e.isComposing) return
             if (e.key === 'Enter') {
                 switch (keyToSendMessage) {
                     case 'Enter':


### PR DESCRIPTION
Should fix #56.