### PR TITLE
feat: Windows on ARM support and refactored imgView with touch support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -835,6 +835,88 @@ jobs:
         path: icalingua/build/Icalingua++*.exe
         if-no-files-found: error
 
+  install-windows-arm64:
+    runs-on: windows-2019
+    defaults:
+      run:
+        working-directory: icalingua
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.13.0'
+      - name: Install Yarn
+        run: npm install --global yarn
+      - uses: Icalinguaplusplus/gha-yarn-node-cache@master
+        env:
+          WORKING_DIR: icalingua
+      - name: Fetch node.lib and Yarn install
+        shell: cmd
+        run: |
+          set npm_config_arch=arm64
+          set node_version=16.13.0
+          mkdir %APPDATA%\..\Local\node-gyp\Cache\%node_version%\arm64
+          curl -Lo %APPDATA%\..\Local\node-gyp\Cache\%node_version%\arm64\node.lib https://unofficial-builds.nodejs.org/download/release/v%node_version%/win-arm64/node.lib
+
+          yarn install
+
+  build-windows-arm64:
+    runs-on: windows-2019
+    needs: install-windows-arm64
+    outputs:
+      version: ${{ steps.git-ver.outputs.version }}
+      arch-version: ${{ steps.version.outputs.arch-version }}
+      pkg-name: ${{ steps.version.outputs.pkg-name }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16.13.0'
+
+    - uses: Icalinguaplusplus/gha-yarn-node-cache@master
+      env:
+        WORKING_DIR: icalingua
+
+    - id: git-ver
+      run: echo "::set-output name=version::$(git describe --tags | sed 's/v//')"
+      
+    - name: check version and write version info
+      run: node .github/check-version.js
+      id: version
+      env:
+        SHA: ${{ github.sha }}
+        REF: ${{ github.REF }}
+        GIT_VER: ${{ steps.git-ver.outputs.version }}
+        
+    - name: build
+      shell: cmd
+      run: |
+        set npm_config_arch=arm64
+        set node_version=16.13.0
+        mkdir %APPDATA%\..\Local\node-gyp\Cache\%node_version%\arm64
+        curl -Lo %APPDATA%\..\Local\node-gyp\Cache\%node_version%\arm64\node.lib https://unofficial-builds.nodejs.org/download/release/v%node_version%/win-arm64/node.lib
+
+        cmd.exe /c "yarn deps:woa & yarn build:ci & yarn build:woa"
+      working-directory: icalingua
+
+    - name: rename
+      run: ../../.github/winrename.bat
+      working-directory: icalingua/build
+      
+    - uses: actions/upload-artifact@v2
+      name: Upload Icalingua_Windows_arm64.exe
+      with:
+        name: Icalingua_Windows_arm64.exe
+        path: icalingua/build/Icalingua++*.exe
+        if-no-files-found: error
+
   install-macos-x64:
     runs-on: macos-11
     defaults:

--- a/icalingua/package.json
+++ b/icalingua/package.json
@@ -8,8 +8,11 @@
   "desktopName": "icalingua.desktop",
   "homepage": "https://github.com/Icalingua-plus-plus/Icalingua-plus-plus",
   "scripts": {
+    "deps:woa:sqlite3": "cd node_modules/sqlite3 && cross-env npm_config_arch=arm64 npx node-pre-gyp configure --target_arch=arm64 && cross-env npm_config_arch=arm64 npx node-pre-gyp build --target_arch=arm64",
+    "deps:woa": "npm run deps:woa:sqlite3",
     "build": "ts-node .electron-vue/build.ts && electron-builder",
     "build:win": "electron-builder --win",
+    "build:woa": "cross-env npm_config_arch=arm64 electron-builder --win --arm64",
     "build:arm": "electron-builder --arm",
     "build:electron": "electron-builder",
     "build:ci": "ts-node .electron-vue/build.ts",

--- a/icalingua/static/imgView.html
+++ b/icalingua/static/imgView.html
@@ -1,9 +1,14 @@
 <html>
 
 <head>
+	<meta name="viewport" content="width=device-width; initial-scale=1.0, maximum-scale=1.0, user-scalable=no;" />
 	<style>
 		body {
 			background: black;
+		}
+
+		#DRAG {
+			touch-action:none;
 		}
 
 		.btn {
@@ -155,37 +160,74 @@
 		deployLT()
 	}
 
-	// Drag support
+	// Drag and pinch support
 	var starT, starTLT
-	DRAG.onmousedown = function (ev) {
+	var evCache = new Array()
+	var touchInitialZoom, firstPinchDistanceX, firstPinchDistanceY
+
+	DRAG.onpointerdown = function (ev) {
 		var e = ev || window.event
+
 		starT = [e.clientX, e.clientY]
 		starTLT = [IMG.offsetLeft, IMG.offsetTop]
-		window.addEventListener('mousemove', mousemove)
-		window.addEventListener('mouseup', mouseup)
+		evCache.push(e)
+		touchInitialZoom = zoom
+		window.addEventListener('pointermove', pointermove)
 	}
-	function mousemove(ev) {
+
+	function pointermove(ev) {
 		var e = ev || window.event
-
-		if (starT == null) return
-
-		if (centerX < 0 || centerY < 0) {
-			centerX = 50
-			centerY = 50
+		for (var i = 0; i < evCache.length; i++) {
+			if (ev.pointerId == evCache[i].pointerId) {
+				evCache[i] = ev
+				break;
+			}
 		}
+		if (evCache.length == 1) {
+			if (starT == null) return
 
-		IMG.style.left = e.clientX - starT[0] + starTLT[0]
-		IMG.style.top = e.clientY - starT[1] + starTLT[1]
+			if (centerX < 0 || centerY < 0) {
+				centerX = 50
+				centerY = 50
+			}
+			
+			IMG.style.left = e.clientX - starT[0] + starTLT[0]
+			IMG.style.top = e.clientY - starT[1] + starTLT[1]
 
-		centerX = (IMG.offsetRight - IMG.offsetLeft) * 50 / body.clientWidth
-		centerY = (IMG.offsetBottom - IMG.offsetTop) * 50 / body.clientHeight
+			centerX = (IMG.offsetRight - IMG.offsetLeft) * 50 / body.clientWidth
+			centerY = (IMG.offsetBottom - IMG.offsetTop) * 50 / body.clientHeight
+		}
+		else if (evCache.length == 2) {
+			const ev0 = evCache[0], ev1 = evCache[1]
+			const distanceX = Math.abs(ev0.clientX - ev1.clientX), distanceY = Math.abs(ev0.clientY - ev1.clientY)
+			if (!firstPinchDistanceX) firstPinchDistanceX = distanceX
+			if (!firstPinchDistanceY) firstPinchDistanceY = distanceY
+
+			const ratio = Math.sqrt(
+				Math.pow(distanceX / firstPinchDistanceX, 2) + 
+				Math.pow(distanceY / firstPinchDistanceY, 2)
+			) / Math.SQRT2 
+			
+			if (touchInitialZoom * ratio >= 0.3)
+				setZoom(e, touchInitialZoom * ratio)
+		}
 	}
 
-
-	function mouseup(ev) {
-		starT = null
-		window.removeEventListener('mousemove', mousemove)
-		window.removeEventListener('mouseup', mouseup)
+	DRAG.onpointerup = function(ev) {
+		for (var i = 0; i < evCache.length; i++) {
+			if (evCache[i].pointerId == ev.pointerId) {
+				evCache.splice(i, 1)
+				break
+			}
+		}
+		if (evCache.length == 1) starT = null
+		if (evCache.length < 2) {
+			touchInitialZoom = undefined
+			firstPinchDistanceX = undefined
+			firstPinchDistanceY = undefined
+		}
+		
+		window.removeEventListener('pointermove', pointermove)
 	}
 
 	// deploy buttons
@@ -194,37 +236,53 @@
 		return 'rotate(' + rotate + 'deg) scale(' + zoom + ',' + zoom + ')'
 	}
 
+	function resetZoom() {
+		// toggle
+		toggle = !toggle
+		zoom = 1
+		IMG.style.transform = mkTransform(rotate, zoom)
+		adapt(toggle)
+	}
+
+	function rotateAntiClockwise() {
+		rotate -= 90
+		if (!rotate % 360) rotate = 0
+		IMG.style.transform = mkTransform(rotate, zoom)
+	}
+
+	function rotateClockwise() {
+		rotate += 90
+		if (!rotate % 360) rotate = 0
+		IMG.style.transform = mkTransform(rotate, zoom)
+	}
+
+	function zoomIn(e, ratio=0.2) {
+		scale = zoom
+		zoom += ratio
+		IMG.style.transform = mkTransform(rotate, zoom)
+		updatePosition(e)
+	}
+
+	function zoomOut(e, ratio=0.2) {
+		if (zoom < 0.3) return
+		scale = zoom
+		zoom -= ratio
+		IMG.style.transform = mkTransform(rotate, zoom)
+		updatePosition(e)
+	}
+
+	function setZoom(e, target) {
+		scale = zoom
+		zoom = target
+		IMG.style.transform = mkTransform(rotate, zoom)
+		updatePosition(e)
+	}
+
+	function download() {
+		DOWNLOAD.dispatchEvent(new MouseEvent('click'))
+	}
 	var btnactions = [
-		function () {
-			// toggle
-			toggle = !toggle
-			zoom = 1
-			IMG.style.transform = mkTransform(rotate, zoom)
-			adapt(toggle)
-		}, function () {
-			rotate -= 90
-			if (!rotate % 360) rotate = 0
-			IMG.style.transform = mkTransform(rotate, zoom)
-		}, function () {
-			rotate += 90
-			if (!rotate % 360) rotate = 0
-			IMG.style.transform = mkTransform(rotate, zoom)
-		}, function (e) {
-			// zoom in
-			scale = zoom
-			zoom += 0.2
-			IMG.style.transform = mkTransform(rotate, zoom)
-			updatePosition(e)
-		}, function (e) {
-			if (zoom < 0.3) return
-			scale = zoom
-			zoom -= 0.2
-			IMG.style.transform = mkTransform(rotate, zoom)
-			updatePosition(e)
-		}, function () {
-			// Download!
-			DOWNLOAD.dispatchEvent(new MouseEvent('click'))
-		}
+		resetZoom, rotateAntiClockwise, rotateClockwise, zoomIn, zoomOut, download
 	]
 
 	var btns = document.getElementsByTagName('button')
@@ -232,7 +290,7 @@
 		btns[i].onclick = btnactions[i]
 	}
 
-	IMG.onload = btnactions[0]
+	IMG.onload = resetZoom
 
 	// ajust focus 
 	function updatePosition(e) {
@@ -254,10 +312,10 @@
 
 	DRAG.onwheel = e => {
 		if (e.wheelDeltaY > 0) {
-			btnactions[3](e)
+			zoomIn(e, e.wheelDeltaY / body.clientHeight)
 		}
 		else if (e.wheelDeltaY < 0) {
-			btnactions[4](e)
+			zoomOut(e, -e.wheelDeltaY / body.clientHeight)
 		}
 	}
 

--- a/icalingua/static/imgView.html
+++ b/icalingua/static/imgView.html
@@ -173,6 +173,7 @@
 		evCache.push(e)
 		touchInitialZoom = zoom
 		window.addEventListener('pointermove', pointermove)
+		window.addEventListener('pointerup', pointerup)
 	}
 
 	function pointermove(ev) {
@@ -227,10 +228,11 @@
 			firstPinchDistanceY = undefined
 		}
 		
-		window.removeEventListener('pointermove', pointermove)
+		if (evCache.length == 0) {
+			window.removeEventListener('pointermove', pointermove)
+			window.removeEventListener('pointerup', pointerup)
+		}
 	}
-	DRAG.onpointerup = pointerup
-	DRAG.onpointerleave = pointerup
 
 	// deploy buttons
 

--- a/icalingua/static/imgView.html
+++ b/icalingua/static/imgView.html
@@ -213,7 +213,7 @@
 		}
 	}
 
-	DRAG.onpointerup = function(ev) {
+	function pointerup(ev) {
 		for (var i = 0; i < evCache.length; i++) {
 			if (evCache[i].pointerId == ev.pointerId) {
 				evCache.splice(i, 1)
@@ -229,6 +229,8 @@
 		
 		window.removeEventListener('pointermove', pointermove)
 	}
+	DRAG.onpointerup = pointerup
+	DRAG.onpointerleave = pointerup
 
 	// deploy buttons
 

--- a/icalingua/yarn.lock
+++ b/icalingua/yarn.lock
@@ -1106,7 +1106,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aproba@npm:^1.0.3, aproba@npm:^1.1.1":
+"aproba@npm:^1.1.1":
   version: 1.2.0
   resolution: "aproba@npm:1.2.0"
   checksum: 0fca141966559d195072ed047658b6e6c4fe92428c385dd38e288eacfc55807e7b4989322f030faff32c0f46bb0bc10f1e0ac32ec22d25315a1e5bbc0ebb76dc
@@ -1130,16 +1130,6 @@ __metadata:
     delegates: ^1.0.0
     readable-stream: ^3.6.0
   checksum: 348edfdd931b0b50868b55402c01c3f64df1d4c229ab6f063539a5025fd6c5f5bb8a0cab409bbed8d75d34762d22aa91b7c20b4204eb8177063158d9ba792981
-  languageName: node
-  linkType: hard
-
-"are-we-there-yet@npm:~1.1.2":
-  version: 1.1.5
-  resolution: "are-we-there-yet@npm:1.1.5"
-  dependencies:
-    delegates: ^1.0.0
-    readable-stream: ^2.0.6
-  checksum: 9a746b1dbce4122f44002b0c39fbba5b2c6f52c00e88b6ccba6fc68652323f8a1355a20e8ab94846995626d8de3bf67669a3b4a037dff0885db14607168f2b15
   languageName: node
   linkType: hard
 
@@ -3116,31 +3106,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacache@npm:^15.0.5":
-  version: 15.2.0
-  resolution: "cacache@npm:15.2.0"
-  dependencies:
-    "@npmcli/move-file": ^1.0.1
-    chownr: ^2.0.0
-    fs-minipass: ^2.0.0
-    glob: ^7.1.4
-    infer-owner: ^1.0.4
-    lru-cache: ^6.0.0
-    minipass: ^3.1.1
-    minipass-collect: ^1.0.2
-    minipass-flush: ^1.0.5
-    minipass-pipeline: ^1.2.2
-    mkdirp: ^1.0.3
-    p-map: ^4.0.0
-    promise-inflight: ^1.0.1
-    rimraf: ^3.0.2
-    ssri: ^8.0.1
-    tar: ^6.0.2
-    unique-filename: ^1.1.1
-  checksum: 34d0fba6030dd3f1f9de4d9fb486cfa8f6ec836ab00d75b846b40c06f96e64898e781f715d19a2c357a601a899c339a44446f94dd328f173605af165a295dd29
-  languageName: node
-  linkType: hard
-
 "cacache@npm:^15.2.0":
   version: 15.3.0
   resolution: "cacache@npm:15.3.0"
@@ -3596,13 +3561,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"code-point-at@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "code-point-at@npm:1.1.0"
-  checksum: 17d5666611f9b16d64fdf48176d9b7fb1c7d1c1607a189f7e600040a11a6616982876af148230336adb7d8fe728a559f743a4e29db3747e3b1a32fa7f4529681
-  languageName: node
-  linkType: hard
-
 "collection-visit@npm:^1.0.0":
   version: 1.0.0
   resolution: "collection-visit@npm:1.0.0"
@@ -3914,7 +3872,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"console-control-strings@npm:^1.0.0, console-control-strings@npm:^1.1.0, console-control-strings@npm:~1.1.0":
+"console-control-strings@npm:^1.0.0, console-control-strings@npm:^1.1.0":
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
   checksum: 8755d76787f94e6cf79ce4666f0c5519906d7f5b02d4b884cf41e11dcd759ed69c57da0670afd9236d229a46e0f9cf519db0cd829c6dca820bb5a5c3def584ed
@@ -6058,22 +6016,6 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"gauge@npm:~2.7.3":
-  version: 2.7.4
-  resolution: "gauge@npm:2.7.4"
-  dependencies:
-    aproba: ^1.0.3
-    console-control-strings: ^1.0.0
-    has-unicode: ^2.0.0
-    object-assign: ^4.1.0
-    signal-exit: ^3.0.0
-    string-width: ^1.0.1
-    strip-ansi: ^3.0.1
-    wide-align: ^1.1.0
-  checksum: a89b53cee65579b46832e050b5f3a79a832cc422c190de79c6b8e2e15296ab92faddde6ddf2d376875cbba2b043efa99b9e1ed8124e7365f61b04e3cee9d40ee
-  languageName: node
-  linkType: hard
-
 "get-caller-file@npm:^2.0.1, get-caller-file@npm:^2.0.5":
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
@@ -6384,7 +6326,7 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"has-unicode@npm:^2.0.0, has-unicode@npm:^2.0.1":
+"has-unicode@npm:^2.0.1":
   version: 2.0.1
   resolution: "has-unicode@npm:2.0.1"
   checksum: 1eab07a7436512db0be40a710b29b5dc21fa04880b7f63c9980b706683127e3c1b57cb80ea96d47991bdae2dfe479604f6a1ba410106ee1046a41d1bd0814400
@@ -7319,15 +7261,6 @@ fsevents@~2.3.1:
   version: 1.1.0
   resolution: "is-finite@npm:1.1.0"
   checksum: 532b97ed3d03e04c6bd203984d9e4ba3c0c390efee492bad5d1d1cd1802a68ab27adbd3ef6382f6312bed6c8bb1bd3e325ea79a8dc8fe080ed7a06f5f97b93e7
-  languageName: node
-  linkType: hard
-
-"is-fullwidth-code-point@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "is-fullwidth-code-point@npm:1.0.0"
-  dependencies:
-    number-is-nan: ^1.0.0
-  checksum: 4d46a7465a66a8aebcc5340d3b63a56602133874af576a9ca42c6f0f4bd787a743605771c5f246db77da96605fefeffb65fc1dbe862dcc7328f4b4d03edf5a57
   languageName: node
   linkType: hard
 
@@ -8477,29 +8410,6 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"make-fetch-happen@npm:^8.0.14":
-  version: 8.0.14
-  resolution: "make-fetch-happen@npm:8.0.14"
-  dependencies:
-    agentkeepalive: ^4.1.3
-    cacache: ^15.0.5
-    http-cache-semantics: ^4.1.0
-    http-proxy-agent: ^4.0.1
-    https-proxy-agent: ^5.0.0
-    is-lambda: ^1.0.1
-    lru-cache: ^6.0.0
-    minipass: ^3.1.3
-    minipass-collect: ^1.0.2
-    minipass-fetch: ^1.3.2
-    minipass-flush: ^1.0.5
-    minipass-pipeline: ^1.2.4
-    promise-retry: ^2.0.1
-    socks-proxy-agent: ^5.0.0
-    ssri: ^8.0.0
-  checksum: 326fefde1aec1f1314e548be74baaaa322208718d1b51c9688a326f73dea70f57767b4f5423230e39408cfe7c6dcf7adcf86ca4798c919c3ea78f54532910434
-  languageName: node
-  linkType: hard
-
 "make-fetch-happen@npm:^9.1.0":
   version: 9.1.0
   resolution: "make-fetch-happen@npm:9.1.0"
@@ -9205,7 +9115,7 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:8.x":
+"node-gyp@npm:8.x, node-gyp@npm:latest":
   version: 8.4.1
   resolution: "node-gyp@npm:8.4.1"
   dependencies:
@@ -9222,26 +9132,6 @@ fsevents@~2.3.1:
   bin:
     node-gyp: bin/node-gyp.js
   checksum: 341710b5da39d3660e6a886b37e210d33f8282047405c2e62c277bcc744c7552c5b8b972ebc3a7d5c2813794e60cc48c3ebd142c46d6e0321db4db6c92dd0355
-  languageName: node
-  linkType: hard
-
-"node-gyp@npm:latest":
-  version: 8.1.0
-  resolution: "node-gyp@npm:8.1.0"
-  dependencies:
-    env-paths: ^2.2.0
-    glob: ^7.1.4
-    graceful-fs: ^4.2.6
-    make-fetch-happen: ^8.0.14
-    nopt: ^5.0.0
-    npmlog: ^4.1.2
-    rimraf: ^3.0.2
-    semver: ^7.3.5
-    tar: ^6.1.0
-    which: ^2.0.2
-  bin:
-    node-gyp: bin/node-gyp.js
-  checksum: d9f11a9ab20d2ec900cd910ecd77bc3909d4b5cd9eaf9854b00be4ba930227c5ce2ee0681216c326739dd445b1787aa933ac8d6a16ce222455d85092bb047901
   languageName: node
   linkType: hard
 
@@ -9376,18 +9266,6 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"npmlog@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "npmlog@npm:4.1.2"
-  dependencies:
-    are-we-there-yet: ~1.1.2
-    console-control-strings: ~1.1.0
-    gauge: ~2.7.3
-    set-blocking: ~2.0.0
-  checksum: edbda9f95ec20957a892de1839afc6fb735054c3accf6fbefe767bac9a639fd5cea2baeac6bd2bcd50a85cb54924d57d9886c81c7fbc2332c2ddd19227504192
-  languageName: node
-  linkType: hard
-
 "npmlog@npm:^5.0.1":
   version: 5.0.1
   resolution: "npmlog@npm:5.0.1"
@@ -9425,13 +9303,6 @@ fsevents@~2.3.1:
   version: 1.2.2
   resolution: "num2fraction@npm:1.2.2"
   checksum: 1da9c6797b505d3f5b17c7f694c4fa31565bdd5c0e5d669553253aed848a580804cd285280e8a73148bd9628839267daee4967f24b53d4e893e44b563e412635
-  languageName: node
-  linkType: hard
-
-"number-is-nan@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "number-is-nan@npm:1.0.1"
-  checksum: 13656bc9aa771b96cef209ffca31c31a03b507ca6862ba7c3f638a283560620d723d52e626d57892c7fff475f4c36ac07f0600f14544692ff595abff214b9ffb
   languageName: node
   linkType: hard
 
@@ -10891,7 +10762,7 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:1 || 2, readable-stream@npm:2.3.7, readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.1, readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.6, readable-stream@npm:^2.1.5, readable-stream@npm:^2.2.2, readable-stream@npm:^2.3.3, readable-stream@npm:^2.3.5, readable-stream@npm:^2.3.6, readable-stream@npm:^2.3.7, readable-stream@npm:~2.3.6":
+"readable-stream@npm:1 || 2, readable-stream@npm:2.3.7, readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.1, readable-stream@npm:^2.0.2, readable-stream@npm:^2.1.5, readable-stream@npm:^2.2.2, readable-stream@npm:^2.3.3, readable-stream@npm:^2.3.5, readable-stream@npm:^2.3.6, readable-stream@npm:^2.3.7, readable-stream@npm:~2.3.6":
   version: 2.3.7
   resolution: "readable-stream@npm:2.3.7"
   dependencies:
@@ -11626,7 +11497,7 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"set-blocking@npm:^2.0.0, set-blocking@npm:~2.0.0":
+"set-blocking@npm:^2.0.0":
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
   checksum: 6e65a05f7cf7ebdf8b7c75b101e18c0b7e3dff4940d480efed8aad3a36a4005140b660fa1d804cb8bce911cac290441dc728084a30504d3516ac2ff7ad607b02
@@ -11785,7 +11656,7 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"smart-buffer@npm:^4.1.0, smart-buffer@npm:^4.2.0":
+"smart-buffer@npm:^4.2.0":
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
   checksum: b5167a7142c1da704c0e3af85c402002b597081dd9575031a90b4f229ca5678e9a36e8a374f1814c8156a725d17008ae3bde63b92f9cfd132526379e580bec8b
@@ -11909,17 +11780,6 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "socks-proxy-agent@npm:5.0.1"
-  dependencies:
-    agent-base: ^6.0.2
-    debug: 4
-    socks: ^2.3.3
-  checksum: 1b60c4977b2fef783f0fc4dc619cd2758aafdb43f3cf679f1e3627cb6c6e752811cee5513ebb4157ad26786033d2f85029440f197d321e8293b38cc5aab01e06
-  languageName: node
-  linkType: hard
-
 "socks-proxy-agent@npm:^6.0.0":
   version: 6.2.0
   resolution: "socks-proxy-agent@npm:6.2.0"
@@ -11928,16 +11788,6 @@ fsevents@~2.3.1:
     debug: ^4.3.3
     socks: ^2.6.2
   checksum: 6723fd64fb50334e2b340fd0a80fd8488ffc5bc43d85b7cf1d25612044f814dd7d6ea417fd47602159941236f7f4bd15669fa5d7e1f852598a31288e1a43967b
-  languageName: node
-  linkType: hard
-
-"socks@npm:^2.3.3":
-  version: 2.6.1
-  resolution: "socks@npm:2.6.1"
-  dependencies:
-    ip: ^1.1.5
-    smart-buffer: ^4.1.0
-  checksum: 2ca9d616e424f645838ebaabb04f85d94ea999e0f8393dc07f86c435af22ed88cb83958feeabd1bb7bc537c635ed47454255635502c6808a6df61af1f41af750
   languageName: node
   linkType: hard
 
@@ -12291,17 +12141,6 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"string-width@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "string-width@npm:1.0.2"
-  dependencies:
-    code-point-at: ^1.0.0
-    is-fullwidth-code-point: ^1.0.0
-    strip-ansi: ^3.0.0
-  checksum: 5c79439e95bc3bd7233a332c5f5926ab2ee90b23816ed4faa380ce3b2576d7800b0a5bb15ae88ed28737acc7ea06a518c2eef39142dd727adad0e45c776cd37e
-  languageName: node
-  linkType: hard
-
 "string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
@@ -12313,7 +12152,7 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"string-width@npm:^1.0.2 || 2, string-width@npm:^2.0.0":
+"string-width@npm:^2.0.0":
   version: 2.1.1
   resolution: "string-width@npm:2.1.1"
   dependencies:
@@ -12577,7 +12416,7 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"tar@npm:^6.0.2, tar@npm:^6.1.0":
+"tar@npm:^6.0.2":
   version: 6.1.8
   resolution: "tar@npm:6.1.8"
   dependencies:
@@ -13887,15 +13726,6 @@ fsevents@~2.3.1:
   bin:
     node-which: ./bin/node-which
   checksum: 1a5c563d3c1b52d5f893c8b61afe11abc3bab4afac492e8da5bde69d550de701cf9806235f20a47b5c8fa8a1d6a9135841de2596535e998027a54589000e66d1
-  languageName: node
-  linkType: hard
-
-"wide-align@npm:^1.1.0":
-  version: 1.1.3
-  resolution: "wide-align@npm:1.1.3"
-  dependencies:
-    string-width: ^1.0.2 || 2
-  checksum: d09c8012652a9e6cab3e82338d1874a4d7db2ad1bd19ab43eb744acf0b9b5632ec406bdbbbb970a8f4771a7d5ef49824d038ba70aa884e7723f5b090ab87134d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I've made two major changes in this fork:
- ARM64 support for Windows
- Restructured the code of imgView and support drag and pinching with touch screen.
  + Functions are named instead of elements in `btnactions`.
  + Use pointer events to unify the events and support multi-touch.
  + Change the ratio of wheel zooming.

It also contains a modification of `yarn.lock`, which is `node-gyp@npm:latest`. I've locked it to `8.4.1` to support Visual Studio 2022 toolchain.
The pinch gesture implementation is a cooperation of me and @RayleighZ.
It's a pity that this fork currently does not fix the image center problem.

The new build has tested on my Surface Pro X.

Thank you very much for the maintanance.