### PR TITLE
feat: 增加重新獲取消息選項

### DIFF
--- a/icalingua-bridge-oicq/adapters/oicqAdapter.ts
+++ b/icalingua-bridge-oicq/adapters/oicqAdapter.ts
@@ -1483,6 +1483,36 @@ const adapter = {
     async hideMessage(roomId: number, messageId: string) {
         await storage.updateMessage(roomId, messageId, { hide: true, reveal: false })
     },
+    async renewMessage(roomId: number, messageId: string, message: Message) {
+        const res = await bot.getMsg(messageId)
+        if (!res.error) {
+            const data = res.data
+            const newMessage: Message = {
+                senderId: message.senderId,
+                username: message.username,
+                content: '',
+                timestamp: message.timestamp,
+                date: message.date,
+                _id: messageId,
+                time: message.time,
+                role: message.role,
+                title: message.title,
+                files: [],
+                anonymousId: message.anonymousId,
+                anonymousflag: message.anonymousflag,
+            }
+            try {
+                await processMessage(data.message, newMessage, {}, roomId)
+                await storage.replaceMessage(roomId, messageId, newMessage)
+                clients.renewMessage(roomId, messageId, newMessage)
+            } catch (e) {
+                console.log(e)
+            }
+        } else {
+            if (res.error.message !== 'msg not exists') clients.messageError('错误：' + res.error.message)
+            else clients.messageError('错误：该消息不存在。')
+        }
+    },
     async renewMessageURL(roomId: number, messageId: string | number, URL) {
         clients.renewMessageURL(messageId, URL)
         //await storage.updateURL(roomId, messageId, {file: JSON.stringify({ type: 'video/mp4', url: URL })})

--- a/icalingua-bridge-oicq/handlers/registerSocketHandlers.ts
+++ b/icalingua-bridge-oicq/handlers/registerSocketHandlers.ts
@@ -26,6 +26,7 @@ export default (io: Server, socket: Socket) => {
     socket.on('reLogin', adapter.reLogin)
     socket.on('removeChat', adapter.removeChat)
     socket.on('revealMessage', adapter.revealMessage)
+    socket.on('renewMessage', adapter.renewMessage)
     socket.on('renewMessageURL', adapter.renewMessageURL)
     socket.on('sendGroupPoke', adapter.sendGroupPoke)
     socket.on('sendMessage', adapter.sendMessage)

--- a/icalingua-bridge-oicq/utils/clients.ts
+++ b/icalingua-bridge-oicq/utils/clients.ts
@@ -46,6 +46,9 @@ export default {
     revealMessage(messageId: string | number) {
         broadcast('revealMessage', messageId)
     },
+    renewMessage(roomId: number, messageId: string, message: Message) {
+        broadcast('renewMessage', { roomId, messageId, message })
+    },
     renewMessageURL(messageId: string | number, URL: string) {
         broadcast('renewMessageURL', { messageId, URL })
     },

--- a/icalingua/src/main/adapters/oicqAdapter.ts
+++ b/icalingua/src/main/adapters/oicqAdapter.ts
@@ -1697,6 +1697,37 @@ const adapter: OicqAdapter = {
     async renewMessageURL(roomId: number, messageId: string | number, URL) {
         ui.renewMessageURL(messageId, URL)
     },
+    async renewMessage(roomId: number, messageId: string, message: Message) {
+        const res = await bot.getMsg(messageId)
+        if (!res.error) {
+            const data = res.data
+            const newMessage: Message = {
+                senderId: message.senderId,
+                username: message.username,
+                content: '',
+                timestamp: message.timestamp,
+                date: message.date,
+                _id: messageId,
+                time: message.time,
+                role: message.role,
+                title: message.title,
+                files: [],
+                anonymousId: message.anonymousId,
+                anonymousflag: message.anonymousflag,
+            }
+            try {
+                await processMessage(data.message, newMessage, {}, roomId)
+                await storage.replaceMessage(roomId, messageId, newMessage)
+                if (roomId === ui.getSelectedRoomId()) ui.renewMessage(roomId, messageId, newMessage)
+            } catch (e) {
+                errorHandler(e, true)
+            }
+        } else {
+            errorHandler(res.error, true)
+            if (res.error.message !== 'msg not exists') ui.messageError('错误：' + res.error.message)
+            else ui.messageError('错误：该消息不存在。')
+        }
+    },
     stopFetchingHistory() {
         stopFetching = true
     },

--- a/icalingua/src/main/adapters/socketIoAdapter.ts
+++ b/icalingua/src/main/adapters/socketIoAdapter.ts
@@ -114,6 +114,9 @@ const attachSocketEvents = () => {
     socket.on('closeLoading', ui.closeLoading)
     socket.on('notifyError', ui.notifyError)
     socket.on('revealMessage', ui.revealMessage)
+    socket.on('renewMessage', ({ roomId, messageId, message }: { roomId: number; messageId: string, message: Message }) => {
+        ui.renewMessage(roomId, messageId, message)
+    })
     socket.on('renewMessageURL', ({ messageId, URL }: { messageId: string | number; URL: string }) => {
         ui.renewMessageURL(messageId, URL)
     })
@@ -501,6 +504,9 @@ const adapter: Adapter = {
     },
     revealMessage(roomId: number, messageId: string | number) {
         socket.emit('revealMessage', roomId, messageId)
+    },
+    renewMessage(roomId: number, messageId: string) {
+        socket.emit('renewMessage', roomId, messageId)
     },
     renewMessageURL(roomId: number, messageId: string | number, URL: string) {
         socket.emit('renewMessageURL', roomId, messageId, URL)

--- a/icalingua/src/main/ipc/botAndStorage.ts
+++ b/icalingua/src/main/ipc/botAndStorage.ts
@@ -52,6 +52,7 @@ export const {
     deleteMessage,
     hideMessage,
     revealMessage,
+    renewMessage,
     renewMessageURL,
     fetchHistory,
     stopFetchingHistory,

--- a/icalingua/src/main/ipc/menuManager.ts
+++ b/icalingua/src/main/ipc/menuManager.ts
@@ -41,6 +41,7 @@ import {
     makeForward,
     pinRoom,
     removeChat,
+    renewMessage,
     renewMessageURL,
     requestGfsToken,
     revealMessage,
@@ -1454,6 +1455,12 @@ ipcMain.on('popupMessageMenu', async (_, room: Room, message: Message, sect?: st
                 new MenuItem({
                     label: '获取历史消息',
                     click: () => fetchHistory(message._id as string),
+                }),
+            )
+            menu.append(
+                new MenuItem({
+                    label: '重新获取该消息内容',
+                    click: () => renewMessage(room.roomId, message._id as string, message),
                 }),
             )
         }

--- a/icalingua/src/main/utils/ui.ts
+++ b/icalingua/src/main/utils/ui.ts
@@ -89,6 +89,9 @@ export default {
     revealMessage(messageId: string | number) {
         sendToMainWindow('revealMessage', messageId)
     },
+    renewMessage(roomId: number, messageId: string, message: Message) {
+        sendToMainWindow('renewMessage', { roomId, messageId, message })
+    },
     renewMessageURL(messageId: string | number, URL: string) {
         sendToMainWindow('renewMessageURL', { messageId, URL })
     },

--- a/icalingua/src/renderer/views/ChatView.vue
+++ b/icalingua/src/renderer/views/ChatView.vue
@@ -400,6 +400,13 @@ export default {
                 this.messages = [...this.messages]
             }
         })
+        ipcRenderer.on('renewMessage', (_, {messageId, message}) => {
+            const oldMessage = this.messages.findIndex((e) => e._id === messageId)
+            if (oldMessage!==-1 && message) {
+                this.messages[oldMessage] = message
+                this.messages = [...this.messages]
+            }
+        })
         ipcRenderer.on('renewMessageURL', (_, {messageId, URL}) => {
             const message = this.messages.find((e) => e._id === messageId)
             if (message && URL !== 'error') {

--- a/packages/storageProviders/MongoStorageProvider.ts
+++ b/packages/storageProviders/MongoStorageProvider.ts
@@ -83,6 +83,14 @@ export default class MongoStorageProvider implements StorageProvider {
         } catch (e) {}
     }
 
+    async replaceMessage(
+        roomId: number,
+        messageId: string | number,
+        message: Message
+    ): Promise<any> {
+        return await this.updateMessage(roomId, messageId, message);
+    }
+
     async fetchMessages(
         roomId: number,
         skip: number,

--- a/packages/storageProviders/RedisStorageProvider.ts
+++ b/packages/storageProviders/RedisStorageProvider.ts
@@ -210,6 +210,19 @@ export default class RedisStorageProvider implements StorageProvider {
         );
     }
 
+    /** 实现 {@link StorageProvider} 类的 `replaceMessage` 方法，
+     * 是对 `msg${roomId}` 的“改”操作。
+     *
+     * 在“重新获取消息内容”等需要改动消息内容的事件中被调用。
+     */
+    async replaceMessage(
+        roomId: number,
+        messageId: string | number,
+        message: Message
+    ): Promise<any> {
+        return await this.updateMessage(roomId, messageId, message);
+    }
+
     /** 实现 {@link StorageProvider} 类的 `fetchMessage` 方法，
      * 是对 `msg${roomId}` 的“查多个”操作。
      *

--- a/packages/storageProviders/SQLStorageProvider.ts
+++ b/packages/storageProviders/SQLStorageProvider.ts
@@ -544,6 +544,25 @@ export default class SQLStorageProvider implements StorageProvider {
         }
     }
 
+    /** 实现 {@link StorageProvider} 类的 `replaceMessage` 方法，
+     * 是对 `msg${roomId}` 的“改”操作。
+     *
+     * 在“重新获取消息内容”等需要改动消息内容的事件中被调用。
+     */
+    async replaceMessage(
+        roomId: number,
+        messageId: string | number,
+        message: Message
+    ): Promise<any> {
+        try {
+            await this.db<Message>("messages")
+                .where("_id", "=", `${messageId}`)
+                .update(this.msgConToDB(message, roomId));
+        } catch (e) {
+            throw e;
+        }
+    }
+
     /** 实现 {@link StorageProvider} 类的 `fetchMessage` 方法，
      * 是对 `msg${roomId}` 的“查多个”操作。
      *

--- a/packages/types/Adapter.d.ts
+++ b/packages/types/Adapter.d.ts
@@ -111,6 +111,8 @@ export default interface Adapter {
 
     revealMessage(roomId: number, messageId: string | number): any
 
+    renewMessage(roomId: number, messageId: string, message: Message): any
+
     renewMessageURL(roomId: number, messageId: string | number, URL: string): any
 
     fetchHistory(messageId: string, roomId?: number): any

--- a/packages/types/StorageProvider.d.ts
+++ b/packages/types/StorageProvider.d.ts
@@ -17,6 +17,8 @@ export default interface StorageProvider {
 
     //updateURL(roomId: number, messageId: string | number, message: Record<string, any>): Promise<any>
 
+    replaceMessage(roomId: number, messageId: string | number, message: Message): Promise<any>
+
     fetchMessages(roomId: number, skip: number, limit: number): Promise<Message[]>
 
     getMessage(roomId: number, messageId: string): Promise<Message>


### PR DESCRIPTION
增加重新獲取消息選項，讓用戶自行重試獲取失敗消息內容如語音消息。
![renewMsg before censored](https://user-images.githubusercontent.com/20432565/198366426-54354e86-bc37-42c8-9fb0-251991f3eb39.png)
![renewMsg after censored](https://user-images.githubusercontent.com/20432565/198366438-66a00228-f8dd-40b9-b5b9-4bd53ccce8d5.png)
註：選項名稱現為 "重新获取该消息内容"，而非圖中 "重新获取该消息"。
