### PR TITLE
opt: sub window alignment on multiple screen

### DIFF
--- a/icalingua/src/main/ipc/openImage.ts
+++ b/icalingua/src/main/ipc/openImage.ts
@@ -8,6 +8,7 @@ import ui from '../utils/ui'
 import md5 from 'md5'
 import { newIcalinguaWindow } from '../../utils/IcalinguaWindow'
 import { getMainWindowScreen } from '../utils/windowManager'
+import { toInteger } from 'lodash'
 
 let viewer = ''
 const VIEWERS = ['gwenview', 'eog', 'eom', 'ristretto', 'okular', 'gimp']
@@ -51,9 +52,11 @@ const openImage = (url: string, external: boolean = false, urlList: Array<string
             const bound = viewerWindow.getBounds()
             const screen = getMainWindowScreen()
             if (screen) {
+                const alignX = toInteger(screen.workArea.x + screen.workArea.width / 2 - bound.width / 2);
+                const alignY = toInteger(screen.workArea.y + screen.workArea.height / 2 - bound.height / 2);
                 viewerWindow.setBounds({
-                    x: screen.workArea.x + screen.workArea.width / 2 - bound.width / 2,
-                    y: screen.workArea.y + screen.workArea.height / 2 - bound.height / 2
+                    x: alignX,
+                    y: alignY,
                 })
             }
             viewerWindow.loadURL(

--- a/icalingua/src/main/ipc/openImage.ts
+++ b/icalingua/src/main/ipc/openImage.ts
@@ -7,6 +7,7 @@ import getStaticPath from '../../utils/getStaticPath'
 import ui from '../utils/ui'
 import md5 from 'md5'
 import { newIcalinguaWindow } from '../../utils/IcalinguaWindow'
+import { getMainWindowScreen } from '../utils/windowManager'
 
 let viewer = ''
 const VIEWERS = ['gwenview', 'eog', 'eom', 'ristretto', 'okular', 'gimp']
@@ -19,7 +20,7 @@ try {
             break
         }
     }
-} catch (e) {}
+} catch (e) { }
 
 if (!viewer) {
     for (const i of VIEWERS) {
@@ -46,6 +47,15 @@ const openImage = (url: string, external: boolean = false, urlList: Array<string
             const viewerWindow = newIcalinguaWindow({
                 autoHideMenuBar: true,
             })
+            // get main window screen location
+            const bound = viewerWindow.getBounds()
+            const screen = getMainWindowScreen()
+            if (screen) {
+                viewerWindow.setBounds({
+                    x: screen.workArea.x + screen.workArea.width / 2 - bound.width / 2,
+                    y: screen.workArea.y + screen.workArea.height / 2 - bound.height / 2
+                })
+            }
             viewerWindow.loadURL(
                 'file://' + path.join(getStaticPath(), 'imgView.html') + '?' + querystring.stringify({ url }),
             )

--- a/icalingua/src/main/ipc/openImage.ts
+++ b/icalingua/src/main/ipc/openImage.ts
@@ -21,7 +21,7 @@ try {
             break
         }
     }
-} catch (e) { }
+} catch (e) {}
 
 if (!viewer) {
     for (const i of VIEWERS) {
@@ -52,8 +52,8 @@ const openImage = (url: string, external: boolean = false, urlList: Array<string
             const bound = viewerWindow.getBounds()
             const screen = getMainWindowScreen()
             if (screen) {
-                const alignX = toInteger(screen.workArea.x + screen.workArea.width / 2 - bound.width / 2);
-                const alignY = toInteger(screen.workArea.y + screen.workArea.height / 2 - bound.height / 2);
+                const alignX = toInteger(screen.workArea.x + screen.workArea.width / 2 - bound.width / 2)
+                const alignY = toInteger(screen.workArea.y + screen.workArea.height / 2 - bound.height / 2)
                 viewerWindow.setBounds({
                     x: alignX,
                     y: alignY,
@@ -76,5 +76,7 @@ const openImage = (url: string, external: boolean = false, urlList: Array<string
         ui.messageError('找不到可用的本地查看器')
     }
 }
-ipcMain.on('openImage', (e, url: string, external: boolean = false, urlList: Array<string> = []) => openImage(url, external, urlList))
+ipcMain.on('openImage', (e, url: string, external: boolean = false, urlList: Array<string> = []) =>
+    openImage(url, external, urlList),
+)
 export default openImage

--- a/icalingua/src/main/utils/windowManager.ts
+++ b/icalingua/src/main/utils/windowManager.ts
@@ -21,8 +21,8 @@ export const loadMainWindow = () => {
                 ? '#131415'
                 : '#fff'
             : theme === 'dark'
-            ? '#131415'
-            : '#fff'
+                ? '#131415'
+                : '#fff'
     mainWindow = newIcalinguaWindow({
         height: winSize.height,
         width: winSize.width,
@@ -62,7 +62,7 @@ export const loadMainWindow = () => {
 
     mainWindow.webContents.setWindowOpenHandler((details) => {
         if (new URL(details.url).hostname == 'qun.qq.com') {
-            ;(async () => {
+            ; (async () => {
                 const size = screen.getPrimaryDisplay().size
                 const win = newIcalinguaWindow({
                     height: size.height - 200,
@@ -85,7 +85,7 @@ export const loadMainWindow = () => {
                 await win.loadURL(details.url, { userAgent: 'QQ/8.9.13.9280' })
             })()
         } else if (new URL(details.url).hostname == 'docs.qq.com') {
-            ;(async () => {
+            ; (async () => {
                 const win1 = newIcalinguaWindow({
                     autoHideMenuBar: true,
                 })
@@ -131,8 +131,8 @@ export const refreshMainWindowColor = () => {
                 ? '#131415'
                 : '#fff'
             : getConfig().theme === 'dark'
-            ? '#131415'
-            : '#fff',
+                ? '#131415'
+                : '#fff',
     )
 }
 export const showLoginWindow = (isConfiguringBridge = false) => {
@@ -213,3 +213,13 @@ export const destroyWindow = () => {
     if (requestWindow && !requestWindow.isDestroyed()) requestWindow.destroy()
 }
 export const getLoginWindow = () => loginWindow
+export const getMainWindowScreen = () => {
+    if (mainWindow) {
+        const bounds = mainWindow.getBounds()
+        return screen.getDisplayNearestPoint({
+            x: bounds.x,
+            y: bounds.y
+        })
+    }
+    return null
+}

--- a/icalingua/src/main/utils/windowManager.ts
+++ b/icalingua/src/main/utils/windowManager.ts
@@ -21,8 +21,8 @@ export const loadMainWindow = () => {
                 ? '#131415'
                 : '#fff'
             : theme === 'dark'
-                ? '#131415'
-                : '#fff'
+            ? '#131415'
+            : '#fff'
     mainWindow = newIcalinguaWindow({
         height: winSize.height,
         width: winSize.width,
@@ -62,7 +62,7 @@ export const loadMainWindow = () => {
 
     mainWindow.webContents.setWindowOpenHandler((details) => {
         if (new URL(details.url).hostname == 'qun.qq.com') {
-            ; (async () => {
+            ;(async () => {
                 const size = screen.getPrimaryDisplay().size
                 const win = newIcalinguaWindow({
                     height: size.height - 200,
@@ -85,7 +85,7 @@ export const loadMainWindow = () => {
                 await win.loadURL(details.url, { userAgent: 'QQ/8.9.13.9280' })
             })()
         } else if (new URL(details.url).hostname == 'docs.qq.com') {
-            ; (async () => {
+            ;(async () => {
                 const win1 = newIcalinguaWindow({
                     autoHideMenuBar: true,
                 })
@@ -131,8 +131,8 @@ export const refreshMainWindowColor = () => {
                 ? '#131415'
                 : '#fff'
             : getConfig().theme === 'dark'
-                ? '#131415'
-                : '#fff',
+            ? '#131415'
+            : '#fff',
     )
 }
 export const showLoginWindow = (isConfiguringBridge = false) => {
@@ -218,7 +218,7 @@ export const getMainWindowScreen = () => {
         const bounds = mainWindow.getBounds()
         return screen.getDisplayNearestPoint({
             x: bounds.x,
-            y: bounds.y
+            y: bounds.y,
         })
     }
     return null


### PR DESCRIPTION
Currently sub window can only be opened in the first primary screen, regardless of the location of the main window.

Possible Situations:
- connect the laptop to a monitor via HDMI or etc.
- move the main window to the monitor
- click an image to view the original one, the image will show in the laptop screen
- I need to manually move the image window from the laptop screen to the monitor screen. (annoying)

This PR adjusts the logic, which will open image window in the same screen as the main window locates.

这个PR优化了多窗口下的一个问题：

我在第二个屏幕上浏览聊天记录，点击个图片预览，预览窗口总是在第一个（主）屏幕，影响体验。

调整了图片窗口逻辑，使得弹出的图片窗口会在主窗口相同的屏幕居中打开，而不是之前的，一直在主显示屏居中打开。