### PR TITLE
feat: 增加配置项localImageViewerByDefault，支持默认使用本地查看器打开图片

### DIFF
--- a/icalingua/src/main/ipc/menuManager.ts
+++ b/icalingua/src/main/ipc/menuManager.ts
@@ -891,6 +891,17 @@ export const updateAppMenu = async () => {
                 },
             }),
             new MenuItem({
+                label: '使用本地图片查看器',
+                type: 'checkbox',
+                checked: getConfig().localImageViewerByDefault,
+                click: (menuItem) => {
+                    getConfig().localImageViewerByDefault = menuItem.checked
+                    saveConfigFile()
+                    ui.message('使用本地图片查看器已' + (menuItem.checked ? '开启' : '关闭'))
+                    ui.setLocalImageViewerByDefault(menuItem.checked)
+                },
+            }),
+            new MenuItem({
                 label: 'DEBUG MODE',
                 visible: !version.isProduction && (versionClickTimes >= 3 || getConfig().debugmode === true),
                 submenu: [
@@ -1351,7 +1362,7 @@ ipcMain.on('popupMessageMenu', async (_, room: Room, message: Message, sect?: st
                         },
                     }),
                 )
-                if (file.type.startsWith('image/'))
+                if (file.type.startsWith('image/') && !getConfig().localImageViewerByDefault)
                     menu.append(
                         new MenuItem({
                             label: '使用本地查看器打开',
@@ -1431,7 +1442,7 @@ ipcMain.on('popupMessageMenu', async (_, room: Room, message: Message, sect?: st
                     },
                 }),
             )
-            if (message.file.type.startsWith('image/'))
+            if (message.file.type.startsWith('image/') && !getConfig().localImageViewerByDefault)
                 menu.append(
                     new MenuItem({
                         label: '使用本地查看器打开',

--- a/icalingua/src/main/ipc/system.ts
+++ b/icalingua/src/main/ipc/system.ts
@@ -45,3 +45,5 @@ ipcMain.on('setLastUsedStickerType', (_, type: 'face' | 'remote' | 'stickers' | 
 })
 
 ipcMain.handle('getHideChatImageByDefault', () => getConfig().hideChatImageByDefault)
+
+ipcMain.handle('getLocalImageViewerByDefault', () => getConfig().localImageViewerByDefault)

--- a/icalingua/src/main/utils/configManager.ts
+++ b/icalingua/src/main/utils/configManager.ts
@@ -44,6 +44,7 @@ type AllConfig = {
     silentFetchHistory: boolean
     hideChatImageByDefault: boolean
     disableChatGroups: boolean
+    localImageViewerByDefault: boolean
 }
 
 const configFilePath = argv.config || path.join(app.getPath('userData'), 'config.yaml')
@@ -119,6 +120,7 @@ const defaultConfig: AllConfig = {
     silentFetchHistory: false,
     hideChatImageByDefault: false,
     disableChatGroups: false,
+    localImageViewerByDefault: false
 }
 if (!fs.existsSync(configFilePath) && fs.existsSync(oldConfigFilePath)) {
     migrateData()

--- a/icalingua/src/main/utils/ui.ts
+++ b/icalingua/src/main/utils/ui.ts
@@ -171,4 +171,7 @@ export default {
     uploadProgress(progress: string) {
         sendToMainWindow('uploadProgress', progress)
     },
+    setLocalImageViewerByDefault(enable: boolean) {
+        sendToMainWindow('setLocalImageViewerByDefault', enable)
+    }
 }

--- a/icalingua/src/renderer/components/vac-mod/ChatWindow/Message/Message.vue
+++ b/icalingua/src/renderer/components/vac-mod/ChatWindow/Message/Message.vue
@@ -94,6 +94,7 @@
                             :showForwardPanel="showForwardPanel"
                             :forward-res-id="forwardResId"
                             :hide-chat-image-by-default="hideChatImageByDefault"
+                            :local-image-viewer-by-default="localImageViewerByDefault"
                             @open-forward="$emit('open-forward', $event)"
                             @scroll-to-message="$emit('scroll-to-message', $event)"
                         />
@@ -133,6 +134,7 @@
                             :image-hover="imageHover"
                             :showForwardPanel="showForwardPanel"
                             :hide-chat-image-by-default="hideChatImageByDefault"
+                            :local-image-viewer-by-default="localImageViewerByDefault"
                             @open-file="openFile"
                         >
                             <template v-for="(i, name) in $scopedSlots" #[name]="data">
@@ -151,6 +153,7 @@
                             :image-hover="imageHover"
                             :showForwardPanel="showForwardPanel"
                             :hide-chat-image-by-default="hideChatImageByDefault"
+                            :local-image-viewer-by-default="localImageViewerByDefault"
                             @open-file="openFile"
                         >
                             <template v-for="(i, name) in $scopedSlots" #[name]="data">
@@ -258,6 +261,7 @@ export default {
         forwardResId: { type: String, required: false },
         msgstoForward: { type: Array, required: false },
         hideChatImageByDefault: { type: Boolean, required: true },
+        localImageViewerByDefault: { type: Boolean, required: true },
     },
 
     data() {

--- a/icalingua/src/renderer/components/vac-mod/ChatWindow/Message/MessageImage.vue
+++ b/icalingua/src/renderer/components/vac-mod/ChatWindow/Message/MessageImage.vue
@@ -86,6 +86,7 @@ export default {
         content: { type: String, default: '' },
         showForwardPanel: { type: Boolean, required: true },
         hideChatImageByDefault: { type: Boolean, required: false, default: false },
+        localImageViewerByDefault: { type: Boolean, required: false, default: false },
     },
 
     data() {
@@ -116,7 +117,7 @@ export default {
     methods: {
         openImage() {
             if (this.showForwardPanel) return
-            ipcRenderer.send('openImage', this.file.url, false)
+            ipcRenderer.send('openImage', this.file.url, this.localImageViewerByDefault)
         },
     },
 }

--- a/icalingua/src/renderer/components/vac-mod/ChatWindow/Message/MessageReply.vue
+++ b/icalingua/src/renderer/components/vac-mod/ChatWindow/Message/MessageReply.vue
@@ -68,6 +68,7 @@ export default {
         showForwardPanel: { type: Boolean, required: true },
         forwardResId: { type: String, required: false },
         hideChatImageByDefault: { type: Boolean, required: true },
+        localImageViewerByDefault: { type: Boolean, required: true },
     },
 
     computed: {
@@ -83,7 +84,7 @@ export default {
         },
         openImage(e) {
             if (this.showForwardPanel) return
-            ipcRenderer.send('openImage', this.message.replyMessage.file.url, false)
+            ipcRenderer.send('openImage', this.message.replyMessage.file.url, this.localImageViewerByDefault)
             e.stopPropagation()
         },
     },

--- a/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
+++ b/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
@@ -117,6 +117,7 @@
                                 @del-msg-to-forward="delMsgtoForward"
                                 @scroll-to-message="scrollToMessage"
                                 :hide-chat-image-by-default="hideChatImageByDefault"
+                                :local-image-viewer-by-default="localImageViewerByDefault"
                             >
                                 <template v-for="(index, name) in $scopedSlots" #[name]="data">
                                     <slot :name="name" v-bind="data" />
@@ -441,6 +442,7 @@ export default {
         forwardResId: { type: String, required: false },
         hideChatImageByDefault: { type: Boolean, required: false, default: false },
         lastUnreadCount: { type: Number, required: false, default: 0 },
+        localImageViewerByDefault: { type: Boolean, required: false, default: false },
     },
     data() {
         return {
@@ -747,6 +749,10 @@ export default {
         this.hideChatImageByDefault = await ipc.getHideChatImageByDefault()
         ipcRenderer.on('setHideChatImageByDefault', (_, hideChatImageByDefault) => {
             this.hideChatImageByDefault = hideChatImageByDefault
+        })
+        this.localImageViewerByDefault = await ipc.getLocalImageViewerByDefault()
+        ipcRenderer.on('setLocalImageViewerByDefault', (_, localImageViewerByDefault) => {
+            this.localImageViewerByDefault = localImageViewerByDefault
         })
     },
     methods: {

--- a/icalingua/src/renderer/utils/ipc.ts
+++ b/icalingua/src/renderer/utils/ipc.ts
@@ -206,5 +206,8 @@ const ipc = {
     async getHideChatImageByDefault(): Promise<boolean> {
         return await ipcRenderer.invoke('getHideChatImageByDefault')
     },
+    async getLocalImageViewerByDefault(): Promise<boolean> {
+        return await ipcRenderer.invoke('getLocalImageViewerByDefault')
+    },
 }
 export default ipc


### PR DESCRIPTION
目前当单击图片消息时，默认会使用内置图片查看器打开图片，往往需要再次操作（最大化，1:1）才能查看更清晰的图片。

而本地图片查看器一般是按照自己的使用习惯配置过的，打开图片即可得到自己需要的结果。

所以我增加了一个配置项支持默认使用本地图片查看器打开图片消息。