### PR TITLE
Feat: openImage: fallback to xdg-open

### DIFF
--- a/icalingua/src/main/ipc/openImage.ts
+++ b/icalingua/src/main/ipc/openImage.ts
@@ -11,7 +11,7 @@ import { getMainWindowScreen } from '../utils/windowManager'
 import { toInteger } from 'lodash'
 
 let viewer = ''
-const VIEWERS = ['gwenview', 'eog', 'eom', 'ristretto', 'okular', 'gimp']
+const VIEWERS = ['gwenview', 'eog', 'eom', 'ristretto', 'okular', 'gimp', 'xdg-open']
 
 try {
     const xdgDefault = execFileSync('xdg-mime', ['query', 'default', 'image/jpeg']).toString()

--- a/icalingua/src/main/utils/openMedia.ts
+++ b/icalingua/src/main/utils/openMedia.ts
@@ -3,7 +3,7 @@ import which from 'which'
 import ui from '../utils/ui'
 
 let viewer = ''
-const VIEWERS = ['vlc', 'mpv']
+const VIEWERS = ['vlc', 'mpv', 'xdg-open']
 
 try {
     const xdgDefault = execFileSync('xdg-mime', ['query', 'default', 'video/mp4']).toString()


### PR DESCRIPTION
In some special environment, such as flatpak, there's no xdg-mime or pre-installed file opener, so we need to call flatpak portal by executing xdg-oepn directly.

Signed-off-by: Leohearts <leohearts@leohearts.com>