### PR TITLE
docs: Modify the document in the icalingua-bridge-oicq

### DIFF
--- a/icalingua-bridge-oicq/README.md
+++ b/icalingua-bridge-oicq/README.md
@@ -101,7 +101,7 @@ wget https://fastly.jsdelivr.net/gh/Icalingua-plus-plus/Icalingua-plus-plus@deve
 
 依照上文中的方法，修改公钥即可，然后运行
 
-具体跳转到 [常规步骤](#常规步骤) 的第 4,5 个步骤
+具体跳转到 [常规安装](#常规安装) 的第 4,5 个步骤
 
 #### 启动
 

--- a/icalingua-bridge-oicq/README.md
+++ b/icalingua-bridge-oicq/README.md
@@ -110,42 +110,9 @@ wget https://fastly.jsdelivr.net/gh/Icalingua-plus-plus/Icalingua-plus-plus@deve
 ```bash
 docker compose up -d
 ```
-注意：仅仅如此是不可以使用的，你需要进入容器中获取到容器的 IP 地址，然后将其填入 config.yaml 中的 `host` 选项中。
-
-例如：
-
-```bash
-# 进入指定容器，并开启 shell
-docker exec -it icalingua-bridge-oicq /bin/sh
-
-# 展示容器的 eth0 网卡的 IP 地址，具体请根据实际情况修改
-ip add show eth0
-```
-输出如下内容：
-
-```bash
-918: eth0@if919: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue state UP 
-    link/ether 02:42:ac:14:00:03 brd ff:ff:ff:ff:ff:ff
-    inet 172.20.0.3/16 brd 172.20.255.255 scope global eth0
-       valid_lft forever preferred_lft forever
-```
-即，将 `172.20.0.3` 填入 `config.yaml` 中的 `host` 选项中，它看起来应该是这样的：
-
-```yaml
-host: 172.20.0.3                                                         # 请修改为你自己容器的 IP 地址
-pubKey: 207a067892821e25d770f1fba0c47c11ff4b813e54162ece9eb839e076231ab6 # 请修改为你自己的公钥
-custom: false
-port: 6789                                                               # 构建镜像时已经写死，无需修改，可以修改容器的端口映射
-```
-
-然后重启容器即可。
-
-```bash
-docker compose restart
-```
 当然，仅仅如此也是比较不安全的，你仍然需要反向代理等过程，以保证安全性。
 
-根据示例可知，反向代理时，需要代理的地址为 `http://172.20.0.3:6789`，即容器的 IP 地址和端口号，或者是 `http://127.0.0.1:6789`，即容器映射后的端口，具体请根据实际情况修改。
+反向代理时，需要代理的地址为`http://127.0.0.1:6789`，即容器映射后的端口，具体请根据实际情况修改。
 
 ## 客户端连接方法
 

--- a/icalingua-bridge-oicq/config.yaml
+++ b/icalingua-bridge-oicq/config.yaml
@@ -1,4 +1,4 @@
-host: 127.0.0.1
+host: 0.0.0.0
 pubKey: 207a067892821e25d770f1fba0c47c11ff4b813e54162ece9eb839e076231ab6
 custom: false
 port: 6789


### PR DESCRIPTION
- 删除不必要的获取docker容器ip的步骤
- 修改config.yaml内的host至0.0.0.0
- 修复docker部署中对常规安装的引用链接