### PR TITLE
ci: remove duplicates step: install-macos-x64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -740,35 +740,8 @@ jobs:
           path: icalingua/build/Icalingua++*.exe
           if-no-files-found: error
 
-  install-macos-x64:
-    runs-on: macos-11
-    defaults:
-      run:
-        working-directory: icalingua
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v3
-        with:
-          node-version: "16"
-
-      - name: Install pnpm
-        run: corepack enable
-
-      - name: Cache pnpm and node-modules
-        uses: Icalinguaplusplus/node-pm-action@master
-        with:
-          node-modules: ./node_modules
-          package-manager: pnpm
-
-      - name: pnpm install
-        run: pnpm install
-
   build-macos-x64:
     runs-on: macos-11
-    needs: install-macos-x64
     outputs:
       version: ${{ steps.git-ver.outputs.version }}
       arch-version: ${{ steps.version.outputs.arch-version }}


### PR DESCRIPTION
这个是在很早以前添加的 [install-macos-x64](https://github.com/Icalingua-plus-plus/Icalingua-plus-plus/commit/696ea2ee1b9dac8131fa8acace81c14a61f47a08) 当时是需要 yarn install 
参考: [以前的 install-windows64](https://github.com/Icalingua-plus-plus/Icalingua-plus-plus/blob/696ea2ee1b9dac8131fa8acace81c14a61f47a08/.github/workflows/main.yml#L612)
在[commit e426a00adad87fca6a0c9bf7ae808c0873095a7e](https://github.com/Icalingua-plus-plus/Icalingua-plus-plus/commit/e426a00adad87fca6a0c9bf7ae808c0873095a7e)中清除了install-windows的步骤
但是并没有对install-macos-x64的清除 疑似是当时漏掉了