### PR TITLE
feat: 优化原来窄宽度界面展示，增加竖屏单面板自适应适配模式，可在选项自定义聊天界面开启

### DIFF
--- a/icalingua/src/main/ipc/menuManager.ts
+++ b/icalingua/src/main/ipc/menuManager.ts
@@ -994,6 +994,19 @@ export const updateAppMenu = async () => {
                             ui.setLocalImageViewerByDefault(menuItem.checked)
                         },
                     },
+                    {
+                        label: '启用自适应单面板模式',
+                        type: 'checkbox',
+                        checked: getConfig().useSinglePanel,
+                        click: (menuItem) => {
+                            getConfig().useSinglePanel = menuItem.checked
+                            saveConfigFile()
+                            ui.message(
+                                menuItem.checked ? '已开启，将在宽度较低时使用单面板模式' : '默认不开启，可以手动调整联系人栏到单头像模式',
+                            )
+                            ui.useSinglePanel(menuItem.checked)
+                        },
+                    },
                 ],
             }),
             new MenuItem({

--- a/icalingua/src/main/utils/configManager.ts
+++ b/icalingua/src/main/utils/configManager.ts
@@ -92,6 +92,7 @@ const defaultConfig: AllConfig = {
     disableQLottie: false,
     disableNotification: false,
     lockPassword: '',
+    useSinglePanel: false
 }
 if (!fs.existsSync(configFilePath) && fs.existsSync(oldConfigFilePath)) {
     migrateData()

--- a/icalingua/src/main/utils/ui.ts
+++ b/icalingua/src/main/utils/ui.ts
@@ -180,4 +180,7 @@ export default {
     setDisableQLottie(enable: boolean) {
         sendToMainWindow('setDisableQLottie', enable)
     },
+    useSinglePanel(enable: boolean) {
+        sendToMainWindow('useSinglePanel', enable)
+    },
 }

--- a/icalingua/src/renderer/components/RoomEntry.vue
+++ b/icalingua/src/renderer/components/RoomEntry.vue
@@ -5,6 +5,7 @@
                 <div class="left">
                     <el-badge value="@" :type="room.at === 'all' ? 'warning' : undefined" :hidden="!room.at">
                         <el-avatar size="large" :src="roomAvatar" />
+                        <el-badge class="avatar-only-unread" :value="room.unreadCount" :type="room.priority < priority ? 'info' : undefined"  v-show="room.unreadCount > 0" />
                     </el-badge>
                 </div>
                 <div class="right" :title="desc">
@@ -178,5 +179,15 @@ a {
     .desc {
         display: none;
     }
+}
+
+.avatar-only-unread {
+    display: none;
+}
+.avatar-only .avatar-only-unread {
+    display: block;
+    position: absolute;
+    top: 30px;
+    left: 24px;
 }
 </style>

--- a/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
+++ b/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
@@ -17,10 +17,12 @@
             :menu-actions="menuActions"
             :room="room"
             :members-count="membersCount"
+            :showSinglePanel="showSinglePanel"
             @toggle-rooms-list="$emit('toggle-rooms-list')"
             @menu-action-handler="$emit('menu-action-handler', $event)"
             @pokefriend="$emit('pokefriend')"
             @room-menu="roomMenu"
+            @back-contact="$emit('back-contact')"
             @open-group-member-panel="$emit('open-group-member-panel')"
         >
             <template v-for="(index, name) in $scopedSlots" #[name]="data">
@@ -460,6 +462,7 @@ export default {
         username: { type: String, required: true },
         forwardResId: { type: String, required: false },
         lastUnreadCount: { type: Number, required: false, default: 0 },
+        showSinglePanel: { type: Boolean, require: true, default: false }
     },
     data() {
         return {

--- a/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/RoomHeader.vue
+++ b/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/RoomHeader.vue
@@ -2,6 +2,9 @@
     <div class="vac-room-header vac-app-border-b">
         <slot name="room-header" v-bind="{ room, typingUsers }">
             <div class="vac-room-wrapper">
+                <div v-show="showSinglePanel" class="vac-svg-button vac-room-back" @click="$emit('back-contact')">
+                    <i class="el-icon-back"></i>
+                </div>
                 <div
                     v-if="!singleRoom"
                     class="vac-svg-button vac-toggle-button"
@@ -92,6 +95,7 @@ export default {
         menuActions: { type: Array, required: true },
         room: { type: Object, required: true },
         membersCount: { type: Number, default: 0 },
+        showSinglePanel: { type: Boolean, require: false, default: false }
     },
 
     data() {
@@ -178,6 +182,13 @@ export default {
 
 .vac-room-options {
     margin-left: auto;
+}
+
+.vac-room-back {
+    padding-right: .6rem;
+    padding-left: .2rem;
+    width: 1.5rem;
+    font-size: 1.5rem;
 }
 
 @media only screen and (max-width: 768px) {

--- a/packages/types/AllConfig.d.ts
+++ b/packages/types/AllConfig.d.ts
@@ -40,6 +40,7 @@ type AllConfig = {
     disableQLottie: boolean
     disableNotification: boolean
     lockPassword: string
+    useSinglePanel: boolean
 }
 
 export default AllConfig


### PR DESCRIPTION
看到有个issue #561  提的，仿照tg改的单面板
自适应的
<img src="https://user-images.githubusercontent.com/7233171/219744270-8b955734-930a-49ca-9bca-f2ffaf5e7610.jpg" width="420px">
<img src="https://user-images.githubusercontent.com/7233171/219744286-cd5bc7e0-e547-454b-86a2-7ff6987c81c6.jpg" width="420px">
