### PR TITLE
fix: 在发送图片时将SVG当文件处理，解决SVG当图片发送却无法发送的问题（仍然保留其图片属性使在本地可以查看和打开）

### DIFF
--- a/icalingua-bridge-oicq/adapters/oicqAdapter.ts
+++ b/icalingua-bridge-oicq/adapters/oicqAdapter.ts
@@ -1054,7 +1054,7 @@ const adapter = {
         }
         if (!room) room = await storage.getRoom(roomId)
         if (!roomId) roomId = room.roomId
-        if (file && ((file.type && !file.type.includes('image')) || !file.type)) {
+        if (file && ((file.type && (!file.type.includes('image') || file.type.includes('svg'))) || !file.type)) {
             // //群文件
             // if (roomId > 0) {
             //     clients.messageError('暂时无法向好友发送文件')

--- a/icalingua/src/main/adapters/oicqAdapter.ts
+++ b/icalingua/src/main/adapters/oicqAdapter.ts
@@ -1258,7 +1258,7 @@ const adapter: OicqAdapter = {
         }
         if (!room) room = await storage.getRoom(roomId)
         if (!roomId) roomId = room.roomId
-        if (file && typeof file.type === 'string' && !file.type.includes('image')) {
+        if (file && typeof file.type === 'string' && (!file.type.includes('image') || file.type.includes('svg'))) {
             //群文件
             if (roomId > 0) {
                 bot.sendFile(roomId, file.path, undefined, ui.uploadProgress).then(async (data) => {

--- a/icalingua/src/renderer/views/ChatView.vue
+++ b/icalingua/src/renderer/views/ChatView.vue
@@ -622,7 +622,7 @@ Chromium ${process.versions.chrome}` : ''
             if (!room) room = this.rooms.find((e) => e.roomId === roomId)
             if (!roomId) roomId = room.roomId
             if (file) {
-                if (file.type.includes('image')) {
+                if (file.type.includes('image')  && file.extension != 'svg') {
                     const crypto = require('crypto')
                     const buffer = Buffer.from(await file.blob.arrayBuffer())
                     const imgHashStr = crypto.createHash('md5').update(buffer).digest('hex').toUpperCase()


### PR DESCRIPTION
处理：在发送时将svg排除出图片的范畴（当前）

题外话：或者可以直接去除掉image属性，当文件而不是处理
修改下isImage函数（大概？）