### PR TITLE
提高接收到超长系统信息的体验+修改文案使silentFetchHistory对于后台提示消息生效

### DIFF
--- a/icalingua/src/main/adapters/oicqAdapter.ts
+++ b/icalingua/src/main/adapters/oicqAdapter.ts
@@ -2005,7 +2005,7 @@ const adapter: OicqAdapter = {
             ui.messageSuccess(`${room.roomName}(${Math.abs(roomId)}) 已拉取 ${messages.length} 条消息`)
             ui.clearHistoryCount()
         } else {
-            ui.message(`${room.roomName}(${Math.abs(roomId)}) 已拉取 ${messages.length} 条消息，正在后台继续拉取`)
+            ui.message(`${room.roomName}(${Math.abs(roomId)}) 后台拉取中，已拉取 ${messages.length} 条消息`)
             {
                 const { messages } = await fetchLoop()
                 await storage.addMessages(roomId, messages)

--- a/icalingua/src/renderer/components/vac-mod/ChatWindow/Message/Message.vue
+++ b/icalingua/src/renderer/components/vac-mod/ChatWindow/Message/Message.vue
@@ -438,8 +438,8 @@ export default {
 }
 
 .vac-card-system {
-    max-width: 250px;
-    padding: 8px 4px;
+    width: fit-content;
+    padding: 8px 20px;
     color: var(--chat-message-color-system);
     background: var(--chat-message-bg-color-system);
 }


### PR DESCRIPTION
移除最大宽度限制，宽度改为fit-content（主要是太短了 备注长一点就经常分行），略微增加两侧的padding使信息显示得优雅一些。