### PR TITLE
修复 formatString.ts 中 URL 夹杂表情时的识别 BUG

### DIFF
--- a/icalingua/src/renderer/components/vac-mod/utils/formatString.ts
+++ b/icalingua/src/renderer/components/vac-mod/utils/formatString.ts
@@ -48,8 +48,36 @@ function compileToJSON(str, doLinkify) {
     let minIndexOf = -1
     let minIndexOfKey = null
 
+    let array; //接受正则表达式的返回值
+    const replacements = [] //存储替换数据的起始位置、结束位置、替换内容
+    const regex = /\[Face: +\d{1,3}]/g
+    const replaceCharacter = (string: string, index: number, lastIndex: number, replacement: string): string => {
+        return (
+            string.slice(0, index) +
+            replacement +
+            str.slice(lastIndex)
+        );
+    }
+    while ((array = regex.exec(str)) !== null) {
+        const index: number = array.index
+        const lastIndex: number = regex.lastIndex
+        const replacement: string = array[0]
+        replacements.push({
+            index, lastIndex, replacement
+        })
+        str = replaceCharacter(str, index, lastIndex, ' '.repeat(replacement.length))
+    }
+
     let links = doLinkify ? linkify.find(str) : []
     let minIndexFromLink = false
+
+    for (const {index, lastIndex, replacement} of replacements) { //恢复被替换的数据
+        str = replaceCharacter(str, index, lastIndex, replacement)
+    }
+
+    for (const {index, lastIndex, replacement} of replacements) {
+        str = replaceCharacter(str, index, lastIndex, replacement)
+    }
 
     if (links.length > 0) {
         minIndexOf = str.indexOf(links[0].value)


### PR DESCRIPTION
Fix #680  [BUG] 聊天消息中 URL 紧邻表情时无法正确识别 URL 范围
实现方式是先将消息中的表情文本替换为空格，等 linkify 将 URL 识别后再将表情文本替换回消息中

因为我没有安装完整的环境，所以没有编译后对项目整体进行测试。但是我对 Issue 中提到的几种情况做了简单的单元测试，结果没有问题。（如果可以帮忙测试一下就好了，感激不尽！）
此外，因为 `compileToJSON` 方法本身是一个递归实现，我这种修复 BUG 的实现方法就性能来说不太理想，优化的话可能需要重写 `compileToJSON` 方法。