### PR TITLE
fix: 回复自己时出现滚动按钮

### DIFF
--- a/icalingua/src/renderer/views/ChatView.vue
+++ b/icalingua/src/renderer/views/ChatView.vue
@@ -560,7 +560,7 @@ export default {
             }
             this.messages = [...this.messages, message]
             if (this.lastUnreadCount >= 10 && !message.system) this.lastUnreadCount++
-            if (message.at) this.lastUnreadAt = true
+            if (message.at && message.senderId != this.account) this.lastUnreadAt = true
         })
         ipcRenderer.on('deleteMessage', (_, messageId) => {
             const message = this.messages.find((e) => e._id === messageId)


### PR DESCRIPTION
修复了回复自己的消息时 Icalingua++ 右上角出现滚动按钮的 Bug。
![图片](https://github.com/Icalingua-plus-plus/Icalingua-plus-plus/assets/17371317/8e59f0d5-bb89-404b-b0a2-72067cedfa28)