### PR TITLE
fix: 优化下载器的使用体验，修复一些小Bug

### DIFF
--- a/icalingua/src/main/adapters/oicqAdapter.ts
+++ b/icalingua/src/main/adapters/oicqAdapter.ts
@@ -1787,7 +1787,7 @@ const adapter: OicqAdapter = {
         try {
             meta = bot.acquireGfs(gin).download(fid)
         } catch (e) {
-            errorHandler(e)
+            errorHandler(e, true)
             meta = {
                 name: e.message + '(' + e.code + ')',
                 url: 'error',

--- a/icalingua/src/main/ipc/downloadManager.ts
+++ b/icalingua/src/main/ipc/downloadManager.ts
@@ -14,23 +14,32 @@ import crypto from 'crypto'
 import ChildProcess from 'child_process'
 import errorHandler from '../utils/errorHandler'
 import axios from 'axios'
+import fileType from 'file-type'
+import { Readable } from 'stream'
+import fetch from 'node-fetch'
 
-let aria: Aria2
+let aria2: Aria2 | null = null
 
 export const loadConfig = (config: Aria2Config) => {
-    if (config.enabled) {
-        aria = new Aria2(config)
-        aria.open()
+    const { enabled, slient, ...rest } = config
+    if (enabled) {
+        aria2 = new Aria2({
+            // aria2 在导入 node-fetch 时有问题，手动指定一下
+            fetch,
+            ...rest,
+        })
+        aria2
+            .open()
             .then(() => {
-                ui.messageSuccess('Aria2 RPC connected')
-                console.log('Aria2 RPC connected')
+                ui.messageSuccess('Aria2 RPC 已连接')
+                console.log('Aria2 RPC 已连接')
             })
             .catch((err) => {
-                ui.messageError('Aria2 failed')
-                console.log('Aria2 failed', err)
+                ui.messageError('连接 Aria2 RPC 失败')
+                console.error('连接 Aria2 RPC 失败')
                 errorHandler(err, true)
             })
-    } else aria = null
+    } else aria2 = null
 }
 
 const downloads = new Map<string, DownloadItem>()
@@ -70,7 +79,7 @@ const registerDownload = (item: DownloadItem, url: string, fileName: string) => 
     })
 }
 
-export const download = (url: string, out: string, dir?: string, saveAs = false) => {
+export const download = async (url: string, out: string, dir?: string, saveAs = false) => {
     if (saveAs) {
         const result = dialog.showSaveDialogSync(BrowserWindow.getFocusedWindow() || getMainWindow(), {
             defaultPath: dir ? path.join(dir, out) : out,
@@ -86,15 +95,22 @@ export const download = (url: string, out: string, dir?: string, saveAs = false)
         out = base + ' (' + i + ')' + ext
         i++
     }
-    if (aria) {
-        aria.call('aria2.addUri', [url], { out, dir })
-            .then(() => ui.messageSuccess('Pushed to Aria2 JSON RPC'))
-            .catch((err) => {
-                errorHandler(err, true)
-                ui.messageError('Aria2 failed')
-            })
-    } else if (!downloads.has(url)) {
-        edl.download(getMainWindow(), url, {
+    if (aria2) {
+        try {
+            await aria2.call('aria2.addUri', [url], { out, dir })
+            if (!getConfig().aria2.slient) {
+                ui.messageSuccess(`已创建 Aria2 下载任务 ${out}`)
+            }
+            return
+        } catch (err) {
+            ui.messageError('创建 Aria2 下载任务失败')
+            console.error('创建 Aria2 下载任务失败')
+            errorHandler(err, true)
+            // Aria2 出错时回退到默认下载器
+        }
+    }
+    if (!downloads.has(url)) {
+        await edl.download(getMainWindow(), url, {
             directory: dir,
             filename: out,
             onStarted(item) {
@@ -109,7 +125,7 @@ export const download = (url: string, out: string, dir?: string, saveAs = false)
 
 loadConfig(getConfig().aria2)
 
-const mime2Ext = (mime: string) => {
+const extFromMime = (mime: string) => {
     switch (mime) {
         case 'image/jpeg':
             return 'jpg'
@@ -119,28 +135,64 @@ const mime2Ext = (mime: string) => {
             return 'ico'
         case 'image/svg+xml':
             return 'svg'
+        case 'image/apng':
+            // APNG 向下兼容 PNG，因此使用 .png 拓展名
+            return 'png'
+        case 'image/heif-sequence':
+            return 'heifs'
+        case 'image/heic-sequence':
+            return 'heics'
         case 'image/png':
         case 'image/gif':
         case 'image/webp':
         case 'image/bmp':
+        case 'image/heif':
+        case 'image/heic':
+        case 'image/jxl':
         case 'image/avif':
-        case 'image/apng':
             return mime.split('/')[1]
         default:
-            return 'jpg'
+            return null
+    }
+}
+const extFromStream = async (stream: Readable) => {
+    const type = await fileType.fromStream(stream)
+    if (!type) {
+        return null
+    }
+    switch (type.mime) {
+        case 'image/apng':
+            return 'png'
+        default:
+            return type.ext
     }
 }
 
 const getImageExt = async (url: string) => {
-    const request = await axios.get(url, {
-        responseType: 'stream',
-        headers: {
-            'User-Agent':
-                'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.5249.199 Safari/537.36 ILPP/2',
-            Range: 'bytes=0-5',
-        },
-    })
-    return mime2Ext(request.headers['content-type'])
+    try {
+        const response = await axios.get(url, {
+            responseType: 'stream',
+            headers: {
+                'User-Agent':
+                    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.5249.199 Safari/537.36 ILPP/2',
+                // 参见 file-type/core.js 里的 minimumBytes（未导出）
+                Range: 'bytes=0-4100',
+            },
+        })
+        const ext = extFromMime(response.headers['content-type'])
+        if (ext) {
+            return ext
+        }
+        // 希望服务器返回了 Content-Type，但如果没有，尝试使用 file-type 库
+        const ext2 = await extFromStream(response.data)
+        if (ext2) {
+            return ext2
+        }
+    } catch (err) {
+        console.error(`检测图片类型失败: ${url}`)
+        errorHandler(err, true)
+    }
+    return 'jpg'
 }
 
 /**
@@ -149,12 +201,7 @@ const getImageExt = async (url: string) => {
 export const downloadImage = async (url: string, saveAs = false) => {
     const out = 'QQ_Image_' + new Date().getTime() + '.' + (await getImageExt(url))
     const dir = app.getPath('downloads')
-    download(url, out, aria ? null : dir, saveAs)
-    if (!saveAs)
-        ui.notifySuccess({
-            title: 'Image Saved',
-            message: aria ? out : path.join(dir, out),
-        })
+    await download(url, out, aria2 ? null : dir, saveAs)
 }
 
 export const downloadImage2Open = async (url: string) => {
@@ -184,26 +231,24 @@ export const downloadImage2Open = async (url: string) => {
 }
 
 export const downloadGroupFile = async (gin: number, fid: string, saveAs = false) => {
-    try {
-        const meta = await getGroupFileMeta(gin, fid)
-        if (meta.url === 'error') {
-            ui.notifyError({
-                title: '下载失败',
-                message: meta.name,
-            })
-            return
-        }
-        download(meta.url, meta.name, undefined, saveAs)
-    } catch (e) {
-        ui.notifyError(e)
-        errorHandler(e, true)
+    const meta = await getGroupFileMeta(gin, fid)
+    if (meta.url === 'error') {
+        ui.notifyError({
+            title: '下载失败',
+            message: meta.name,
+        })
+        return
     }
+    await download(meta.url, meta.name, undefined, saveAs)
 }
 
-export const downloadFileByMessageData = (data: { action: string; message: Message; room: Room }, saveAs = false) => {
+export const downloadFileByMessageData = async (
+    data: { action: string; message: Message; room: Room },
+    saveAs = false,
+) => {
     if (data.action === 'download') {
         if (data.message.file.type.includes('image')) {
-            downloadImage(data.message.file.url, saveAs)
+            await downloadImage(data.message.file.url, saveAs)
         } else if (data.message.file.type.toLowerCase().includes('audio/')) {
             const file = data.message.file
             if (file.url === file.name) {
@@ -213,14 +258,14 @@ export const downloadFileByMessageData = (data: { action: string; message: Messa
                 } else {
                     recordPath = path.join(app.getPath('userData'), 'records', file.url)
                 }
-                download(recordPath, 'QQ_Record_' + file.url, undefined, saveAs)
+                await download(recordPath, 'QQ_Record_' + file.url, undefined, saveAs)
             } else {
-                download(file.url, 'QQ_Record_' + new Date().getTime() + '.ogg', undefined, saveAs)
+                await download(file.url, 'QQ_Record_' + new Date().getTime() + '.ogg', undefined, saveAs)
             }
         } else {
             if (data.room.roomId < 0 && data.message.file.fid)
-                downloadGroupFile(-data.room.roomId, data.message.file.fid, saveAs)
-            else download(data.message.file.url, data.message.content, undefined, saveAs)
+                await downloadGroupFile(-data.room.roomId, data.message.file.fid, saveAs)
+            else await download(data.message.file.url, data.message.content, undefined, saveAs)
         }
     }
 }

--- a/icalingua/src/main/utils/configManager.ts
+++ b/icalingua/src/main/utils/configManager.ts
@@ -41,6 +41,7 @@ const emptyLoginForm: LoginForm = {
 }
 const defaultAria2Config: Aria2Config = {
     enabled: false,
+    slient: false,
     host: '127.0.0.1',
     port: 6800,
     secure: false,

--- a/icalingua/src/renderer/views/Aria2Settings.vue
+++ b/icalingua/src/renderer/views/Aria2Settings.vue
@@ -4,6 +4,9 @@
             <el-form-item label="启用">
                 <el-switch v-model="aria2.enabled" />
             </el-form-item>
+            <el-form-item label="静默">
+                <el-switch v-model="aria2.slient" />
+            </el-form-item>
             <el-form-item label="主机">
                 <el-input v-model="aria2.host" />
             </el-form-item>

--- a/packages/types/Aria2Config.d.ts
+++ b/packages/types/Aria2Config.d.ts
@@ -1,5 +1,6 @@
 type Aria2Config = {
     enabled: boolean
+    slient: boolean
     host: string
     port: number
     secure: boolean


### PR DESCRIPTION
* 下载图片时不再出现两条通知（一条“Image Saved”和一条“下载完成”）
  * 考虑到部分用户自行为 Aria2 配置了通知~~其实就是我自己~~，增加了在使用 Aria2 时完全不发出下载通知的选项
* 调整 getImageExt 函数
  * 如 #705 所述，部分 URL 不返回 Content-Type 头，所以 getImageExt 函数将首先尝试从 Content-Type 推断，如果失败则使用 file-type 库，如果还是失败则回退到 jpg
  * 根据 file-type 库的 [README](https://github.com/sindresorhus/file-type/blob/main/readme.md) 和 [core.js](https://github.com/sindresorhus/file-type/blob/e4204df13bf29383d5664c1d070ba8f7956ded58/core.js#L11)，采样大小为 4100 字节，因此 Range 调整为 0-4100，防止 #697 再次出现（因为 file-type 能检测的类型较多，不排除减少采样大小导致检测不准确的可能，故没有选择减小采样大小，并且 file-type 库也不能调整采样大小）
  * 给 getImageExt 套上了一层 try-catch，防止类似 #704 的问题再次发生（不过这只是让拓展名回退到 jpg 而非检测正确的拓展名，可尝试采用 #705 的方案，但我没测试过）
  * 让 APNG 使用 png 拓展名，因为 APNG 向下兼容 PNG（不支持 APNG 的查看器可以将 APNG 作为 PNG 打开）
* 修复 #412
  * 注：aria2 库默认会在 WebSocket 出错后以 HTTP 访问 Aria2 RPC，但 aria2 库在导入 node-fetch 库时有问题，导致这个功能并未生效
  * 如使用 HTTP 也不能访问 Aria2，则回退到默认下载器