### PR TITLE
fix: 退了的群显示错误的成员数

### DIFF
--- a/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
+++ b/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
@@ -495,7 +495,6 @@ export default {
         loadingRooms: { type: Boolean, required: true },
         roomInfo: { type: Function, default: null },
         textareaAction: { type: Function, default: null },
-        membersCount: { type: Number, default: 0 },
         linkify: { type: Boolean, default: true },
         account: { type: Number, required: true },
         username: { type: String, required: true },
@@ -559,6 +558,7 @@ export default {
             mouseSelectArea: null,
             mouseSelectIds: null,
             isMessageEmpty: true,
+            membersCount: 0,
         }
     },
     computed: {
@@ -1521,6 +1521,13 @@ export default {
         async updateGroupMembers() {
             const { roomId } = this.room
             if (roomId < 0) {
+                const group = await ipc.getGroup(-roomId)
+                if (!group) {
+                    // 退了的群获取不到成员数和成员列表
+                    this.membersCount = 0
+                    return
+                }
+                this.membersCount = group.member_count
                 const groupMembers = await ipc.getGroupMembers(-roomId)
                 if (roomId !== this.room.roomId) return
                 const self = groupMembers.find((member) => member.user_id === this.currentUserId)
@@ -1532,7 +1539,7 @@ export default {
                     })
                 }
                 this.groupMembers = groupMembers
-            }
+            } else this.membersCount = 0
         },
         updateMouseSelectAreaStyleImmediately() {
             const el = this.$refs.mouseSelectArea

--- a/icalingua/src/renderer/views/ChatView.vue
+++ b/icalingua/src/renderer/views/ChatView.vue
@@ -833,7 +833,7 @@ Chromium ${process.versions.chrome}` : ''
             if (this.selectedRoomId < 0)
                 ipc.getGroup(-this.selectedRoomId).then(e =>{
                     // 退了的群获取不到 group
-                    if (e) this.membersCount = e.member_count
+                    this.membersCount = e ? e.member_count : 0
                 })
             else
                 this.membersCount = 0

--- a/icalingua/src/renderer/views/ChatView.vue
+++ b/icalingua/src/renderer/views/ChatView.vue
@@ -102,7 +102,6 @@
                     :show-footer="!isShutUp"
                     :loading-rooms="false"
                     :text-formatting="true"
-                    :members-count="membersCount"
                     :linkify="linkify"
                     :account="account"
                     :username="username"
@@ -250,7 +249,6 @@ export default {
             sysInfo: '',
             historyCount: 0,
             dialogAskCheckUpdateVisible: false,
-            membersCount: 0,
             contactsShown: false,
             groupmemberShown: false,
             groupmemberPanelGin: 0,
@@ -830,13 +828,6 @@ Chromium ${process.versions.chrome}` : ''
             this.selectedRoomId = room.roomId
             ipc.setSelectedRoom(room.roomId, room.roomName)
             this.fetchMessage(true)
-            if (this.selectedRoomId < 0)
-                ipc.getGroup(-this.selectedRoomId).then(e =>{
-                    // 退了的群获取不到 group
-                    this.membersCount = e ? e.member_count : 0
-                })
-            else
-                this.membersCount = 0
         },
         downloadImage: ipc.downloadImage,
         pokeGroup(uin) {


### PR DESCRIPTION
由于我之前的疏忽，#719 实际上并未修复切换到退了的群时报错 `TypeError: Cannot read properties of undefined (reading '22')` 的问题，并提交了有问题的修复（会导致从另一个群切换到退了的群时显示错误的成员数）

这个问题实际上是因为开启了“切换会话窗口时自动获取历史消息”，并且手动获取历史消息时也会出现相同的报错

Icalingua-plus-plus/oicq-icalingua-plus-plus#2 修复了获取历史消息时的报错，这个 PR 修复了成员数显示错误的问题