### PR TITLE
feat: 最近表情 (#686)

### DIFF
--- a/icalingua/src/main/ipc/menuManager.ts
+++ b/icalingua/src/main/ipc/menuManager.ts
@@ -1960,12 +1960,9 @@ ipcMain.on('popupStickerMenu', (_, e) => {
         },
     ]).popup({ window: getMainWindow(), ...pos })
 })
-ipcMain.on('popupStickerItemMenu', (_, itemName: string, itemList: Array<string>, pathName: string, e) => {
+ipcMain.on('popupStickerItemMenu', (_, itemName: string, itemList: Array<string>, e) => {
     const bounds = getMainWindow().getContentBounds()
     const pos = { x: e.x - bounds.x, y: e.y - bounds.y }
-    if (pathName && itemList && itemList.length) {
-        itemList = itemList.map((item) => pathName + item)
-    }
     const menu: (Electron.MenuItemConstructorOptions | Electron.MenuItem)[] = []
     menu.push({
         label: '以图片方式发送',

--- a/icalingua/src/renderer/utils/getLottieFace.ts
+++ b/icalingua/src/renderer/utils/getLottieFace.ts
@@ -77,7 +77,7 @@ export default (msgText: string, time: number): string | undefined => {
             return getLottiePath(lottieId)
         }
     }
-    const nameMatch = msgText.match(/^\[([\u4e00-\u9FA5a-zA-Z]{2,5})\]请使用最新版手机QQ体验新功能$/)
+    const nameMatch = msgText.match(/^\[([\u4e00-\u9FA5a-zA-Z]{2,5})\](?:请使用最新版手机QQ体验新功能)?$/)
     if (nameMatch) {
         const lottieId = faceNameToLottie.get(nameMatch[1])
         if (lottieId) {

--- a/icalingua/src/renderer/utils/getLottieFace.ts
+++ b/icalingua/src/renderer/utils/getLottieFace.ts
@@ -1,67 +1,49 @@
 import path from 'path'
 
-const map = new Map<string, number>([
-    ['/打call', 1],
-    ['/变形', 2],
-    ['/嗑到了', 3],
-    ['/仔细分析', 4],
-    ['/加油', 5],
-    ['/我没事', 6],
-    ['/菜汪', 7],
-    ['/崇拜', 8],
-    ['/比心', 9],
-    ['/庆祝', 10],
-    ['/老色痞', 11],
-    ['/吃糖', 12],
-    ['/篮球', 13],
-    ['/惊吓', 14],
-    ['/生气', 15],
-    ['/流泪', 16],
-    ['/蛋糕', 17],
-    ['/鞭炮', 18],
-    ['/烟花', 19],
-    ['/我想开了', 20],
-    ['/舔屏', 21],
-    ['/花朵脸', 22],
-    ['/热化了', 23],
-    ['/打招呼', 24],
-    ['/你真棒棒', 25],
-    ['/酸Q', 26],
-    ['/我方了', 27],
-    ['/大怨种', 28],
-    ['/红包多多', 29],
-    ['[打call]', 1],
-    ['[变形]', 2],
-    ['[嗑到了]', 3],
-    ['[仔细分析]', 4],
-    ['[加油]', 5],
-    ['[我没事]', 6],
-    ['[菜汪]', 7],
-    ['[崇拜]', 8],
-    ['[比心]', 9],
-    ['[庆祝]', 10],
-    ['[老色痞]', 11],
-    ['[吃糖]', 12],
-    ['[篮球]', 13],
-    ['[惊吓]', 14],
-    ['[生气]', 15],
-    ['[流泪]', 16],
-    ['[蛋糕]', 17],
-    ['[鞭炮]', 18],
-    ['[烟花]', 19],
-    ['[我想开了]', 20],
-    ['[舔屏]', 21],
-    ['[花朵脸]', 22],
-    ['[热化了]', 23],
-    ['[打招呼]', 24],
-    ['[你真棒棒]', 25],
-    ['[酸Q]', 26],
-    ['[我方了]', 27],
-    ['[大怨种]', 28],
-    ['[红包多多]', 29],
+export const faceNameToLottie = new Map<string, number>([
+    ['打call', 1],
+    ['变形', 2],
+    ['嗑到了', 3],
+    ['仔细分析', 4],
+    ['加油', 5],
+    ['我没事', 6],
+    ['菜汪', 7],
+    ['崇拜', 8],
+    ['比心', 9],
+    ['庆祝', 10],
+    ['老色痞', 11],
+    ['吃糖', 12],
+    ['篮球', 13],
+    ['惊吓', 14],
+    ['生气', 15],
+    ['流泪', 16],
+    ['蛋糕', 17],
+    ['鞭炮', 18],
+    ['烟花', 19],
+    ['我想开了', 20],
+    ['舔屏', 21],
+    ['花朵脸', 22],
+    ['热化了', 23],
+    ['打招呼', 24],
+    ['你真棒棒', 25],
+    ['酸Q', 26],
+    ['我方了', 27],
+    ['大怨种', 28],
+    ['红包多多', 29],
 ])
 
-const map2 = new Map([
+export const faceIdToLottie = new Map([
+    [311, 1],
+    [312, 2],
+    [313, 3],
+    [314, 4],
+    [315, 5],
+    [316, 6],
+    [317, 7],
+    [318, 8],
+    [319, 9],
+    [320, 10],
+    [321, 11],
     [324, 12],
     [114, 13],
     [325, 14],
@@ -76,34 +58,37 @@ const map2 = new Map([
     [340, 23],
     [341, 24],
     [346, 25],
+    [342, 26],
+    [343, 27],
+    [344, 28],
+    [345, 29],
 ])
 
-export default (msgText: string, time: number): string => {
-    const idReg = msgText.match(/\[QLottie: (\d+)\,(\d+)\]/)
-    if (idReg) {
-        if (msgText !== idReg[0]) return
-        const id = idReg[1]
-        const faceId = parseInt(idReg[2])
-        let qlottie = ''
+export const getLottiePath = (id: number) => {
+    // @ts-ignore
+    return path.join(__static, 'qlottie', `${id}`, `${id}.json`)
+}
 
-        if (faceId >= 311 && faceId <= 321) {
-            qlottie = String(faceId - 310)
-        } else if (faceId >= 342 && faceId <= 345) {
-            qlottie = String(faceId - 316)
-        } else {
-            qlottie = String(map2.get(faceId))
+export default (msgText: string, time: number): string | undefined => {
+    const idMatch = msgText.match(/^\[QLottie: (\d+)\,(\d+)\]$/)
+    if (idMatch) {
+        const lottieId = faceIdToLottie.get(parseInt(idMatch[2])) || parseInt(idMatch[1])
+        if (lottieId) {
+            return getLottiePath(lottieId)
         }
-        if (qlottie === 'undefined') qlottie = ''
-
-        const i = qlottie ? qlottie : String(id)
-        // @ts-ignore
-        return path.join(__static, 'qlottie', i, i + '.json')
-    } else {
-        const id = map.get(msgText.replace('请使用最新版手机QQ体验新功能', ''))
-        if (id) {
-            const i = String(id)
-            // @ts-ignore
-            return path.join(__static, 'qlottie', i, i + '.json')
+    }
+    const nameMatch = msgText.match(/^\[([\u4e00-\u9FA5a-zA-Z]{2,5})\]请使用最新版手机QQ体验新功能$/)
+    if (nameMatch) {
+        const lottieId = faceNameToLottie.get(nameMatch[1])
+        if (lottieId) {
+            return getLottiePath(lottieId)
+        }
+    }
+    const nameMatch2 = msgText.match(/^\/([\u4e00-\u9FA5a-zA-Z]{2,5})$/)
+    if (nameMatch2) {
+        const lottieId = faceNameToLottie.get(nameMatch2[1])
+        if (lottieId) {
+            return getLottiePath(lottieId)
         }
     }
 }

--- a/icalingua/src/renderer/utils/ipc.ts
+++ b/icalingua/src/renderer/utils/ipc.ts
@@ -124,8 +124,8 @@ const ipc = {
     popupStickerMenu(e) {
         ipcRenderer.send('popupStickerMenu', { x: e.screenX, y: e.screenY })
     },
-    popupStickerItemMenu(itemName: string, itemList: Array<string>, pathName: string, e) {
-        ipcRenderer.send('popupStickerItemMenu', itemName, itemList, pathName, { x: e.screenX, y: e.screenY })
+    popupStickerItemMenu(itemName: string, itemList: Array<string>, e) {
+        ipcRenderer.send('popupStickerItemMenu', itemName, itemList, { x: e.screenX, y: e.screenY })
     },
     popupStickerDirMenu(dirName: string, e) {
         ipcRenderer.send('popupStickerDirMenu', dirName, { x: e.screenX, y: e.screenY })


### PR DESCRIPTION
为 本地贴纸 Stickers、漫游贴纸 Remote 和 表情 Face 添加了“最近使用”分组
其中 Stickers 的最近使用为单独的分类（在 Default 左边），限制 32个
Remote 和 Face 的最近使用在最上面，限制两行（分别是 8 和 18 个），在点击表情时会保持当前点击的表情位置不变（除最近使用外），方便多次发送同一个表情
另外为所有超级表情添加了单独的分类