### PR TITLE
feat: 优化猜拳和骰子的发送界面

### DIFF
--- a/icalingua/src/main/ipc/menuManager.ts
+++ b/icalingua/src/main/ipc/menuManager.ts
@@ -1908,10 +1908,10 @@ ipcMain.on('popupTextAreaMenu', (_, e) => {
         },
     ]).popup({ window: getMainWindow(), ...pos })
 })
-ipcMain.on('popupStickerMenu', (_, e) => {
+ipcMain.on('popupStickerMenu', (_, closePanel, e) => {
     const bounds = getMainWindow().getContentBounds()
     const pos = { x: e.x - bounds.x, y: e.y - bounds.y }
-    Menu.buildFromTemplate([
+    const menu: Electron.MenuItemConstructorOptions[] = [
         {
             label: '打开 Stickers 目录',
             type: 'normal',
@@ -1924,7 +1924,6 @@ ipcMain.on('popupStickerMenu', (_, e) => {
             type: 'normal',
             click() {
                 ui.sendRps()
-                ui.closePanel()
             },
         },
         {
@@ -1932,7 +1931,6 @@ ipcMain.on('popupStickerMenu', (_, e) => {
             type: 'normal',
             click() {
                 ui.sendDice()
-                ui.closePanel()
             },
         },
         {
@@ -1944,7 +1942,6 @@ ipcMain.on('popupStickerMenu', (_, e) => {
                     at: [],
                     messageType: 'shake',
                 })
-                ui.closePanel()
             },
         },
         {
@@ -1953,12 +1950,15 @@ ipcMain.on('popupStickerMenu', (_, e) => {
                 sendGroupPoke(Math.abs(ui.getSelectedRoomId()), getUin())
             },
         },
-        {
+    ]
+    if (closePanel) {
+        menu.push({
             label: '关闭面板',
             type: 'normal',
             click: ui.closePanel,
-        },
-    ]).popup({ window: getMainWindow(), ...pos })
+        })
+    }
+    Menu.buildFromTemplate(menu).popup({ window: getMainWindow(), ...pos })
 })
 ipcMain.on('popupStickerItemMenu', (_, itemName: string, itemList: Array<string>, pathName: string, e) => {
     const bounds = getMainWindow().getContentBounds()

--- a/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
+++ b/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
@@ -342,7 +342,7 @@
                         </slot>
                     </div>
 
-                    <div class="vac-svg-button" @click="$emit('stickers-panel')">
+                    <div class="vac-svg-button" @click="$emit('stickers-panel')" @click.right="stickersMenu($event)">
                         <svg-icon name="emoji" />
                     </div>
 
@@ -1517,6 +1517,9 @@ export default {
         textctx: ipc.popupTextAreaMenu,
         roomMenu(e) {
             ipc.popupRoomMenu(this.room.roomId, e)
+        },
+        stickersMenu(e) {
+            ipc.popupStickerMenu(e, false)
         },
         async updateGroupMembers() {
             const { roomId } = this.room

--- a/icalingua/src/renderer/utils/ipc.ts
+++ b/icalingua/src/renderer/utils/ipc.ts
@@ -121,8 +121,8 @@ const ipc = {
     popupTextAreaMenu(e) {
         ipcRenderer.send('popupTextAreaMenu', { text: e.target.value, x: e.screenX, y: e.screenY })
     },
-    popupStickerMenu(e) {
-        ipcRenderer.send('popupStickerMenu', { x: e.screenX, y: e.screenY })
+    popupStickerMenu(e, closePanel: boolean = true) {
+        ipcRenderer.send('popupStickerMenu', closePanel, { x: e.screenX, y: e.screenY })
     },
     popupStickerItemMenu(itemName: string, itemList: Array<string>, pathName: string, e) {
         ipcRenderer.send('popupStickerItemMenu', itemName, itemList, pathName, { x: e.screenX, y: e.screenY })

--- a/icalingua/src/renderer/views/ChatView.vue
+++ b/icalingua/src/renderer/views/ChatView.vue
@@ -196,6 +196,31 @@
             />
         </el-dialog>
         <DialogAskCheckUpdate :show.sync="dialogAskCheckUpdateVisible" />
+        <el-dialog title="发送骰子" :visible.sync="sendDiceShown">
+            <div class="random-select">
+                <el-button @click="sendDice(1)">1</el-button>
+                <el-button @click="sendDice(2)">2</el-button>
+                <el-button @click="sendDice(3)">3</el-button>
+                <el-button @click="sendDice(4)">4</el-button>
+                <el-button @click="sendDice(5)">5</el-button>
+                <el-button @click="sendDice(6)">6</el-button>
+            </div>
+            <span slot="footer">
+                <el-button @click="sendDiceShown = false">取消</el-button>
+                <el-button type="primary" @click="sendDice(0)">随机</el-button>
+            </span>
+        </el-dialog>
+        <el-dialog title="发送猜拳" :visible.sync="sendRpsShown">
+            <div class="random-select">
+                <el-button @click="sendRps(1)">石头</el-button>
+                <el-button @click="sendRps(2)">剪刀</el-button>
+                <el-button @click="sendRps(3)">布</el-button>
+            </div>
+            <span slot="footer">
+                <el-button @click="sendRpsShown = false">取消</el-button>
+                <el-button type="primary" @click="sendRps(0)">随机</el-button>
+            </span>
+        </el-dialog>
     </div>
 </template>
 
@@ -276,6 +301,8 @@ export default {
             usePanguJsRecv: false,
             showPanel: 'contact', // 'chat' or 'contact', 只有showSinglePanel为true有效
             notifyProgresses: new Map(),
+            sendDiceShown: false,
+            sendRpsShown: false,
         }
     },
     async created() {
@@ -509,38 +536,10 @@ export default {
             })
         })
         ipcRenderer.on('sendDice', (_) => {
-            this.$prompt('请输入骰子点数，留空随机', '提示', {
-                confirmButtonText: '确定',
-                cancelButtonText: '取消',
-                inputType: 'number',
-                inputPattern: /^[1-6]$|^$/,
-            }).then(({ value }) => {
-                if (!value) {
-                    value = (Math.floor(Math.random() * 6) + 1).toString()
-                }
-                this.sendMessage({
-                    content: value,
-                    room: this.selectedRoom,
-                    messageType: 'dice',
-                })
-            })
+            this.sendDiceShown = true
         })
         ipcRenderer.on('sendRps', (_) => {
-            this.$prompt('请输入对应数字，1石头、2剪刀、3布、留空随机', '提示', {
-                confirmButtonText: '确定',
-                cancelButtonText: '取消',
-                inputType: 'number',
-                inputPattern: /^[1-3]$|^$/,
-            }).then(({ value }) => {
-                if (!value) {
-                    value = (Math.floor(Math.random() * 3) + 1).toString()
-                }
-                this.sendMessage({
-                    content: value,
-                    room: this.selectedRoom,
-                    messageType: 'rps',
-                })
-            })
+            this.sendRpsShown = true
         })
         ipcRenderer.on('updateRoom', (_, room) => {
             const oldRooms = this.rooms.filter(item => item.roomId !== room.roomId)
@@ -993,7 +992,29 @@ Chromium ${process.versions.chrome}` : ''
         },
         backContact() {
             this.showPanel = 'contact'
-        }
+        },
+        sendDice(value) {
+            if (!value) {
+                value = Math.floor(Math.random() * 6) + 1
+            }
+            this.sendDiceShown = false
+            this.sendMessage({
+                content: value.toString(),
+                room: this.selectedRoom,
+                messageType: 'dice',
+            })
+        },
+        sendRps(value) {
+            if (!value) {
+                value = Math.floor(Math.random() * 3) + 1
+            }
+            this.sendRpsShown = false
+            this.sendMessage({
+                content: value.toString(),
+                room: this.selectedRoom,
+                messageType: 'rps',
+            })
+        },
     },
     computed: {
         cssVars() {
@@ -1207,6 +1228,14 @@ main div {
     }
 
     &.is-single {
+        flex-grow: 1;
+    }
+}
+
+.random-select {
+    display: flex;
+
+    .el-button {
         flex-grow: 1;
     }
 }


### PR DESCRIPTION
将猜拳和骰子的发送界面从输入数字改为点选，并且允许右键表情按钮弹出菜单，快捷发送猜拳、骰子等
![图片](https://github.com/Icalingua-plus-plus/Icalingua-plus-plus/assets/17371317/6e6df1e9-bc62-4092-9a18-0fc3c21929d5)
