### PR TITLE
feat: 将消息输入框的按钮吸底

### DIFF
--- a/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
+++ b/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
@@ -1854,8 +1854,9 @@ export default {
 
 .vac-icon-textarea {
     display: flex;
-    margin: 12px 0 0 5px;
-
+    margin: 12px 0 10px 5px;
+    align-items: flex-end;
+    
     svg,
     .vac-wrapper {
         margin: 0 7px;


### PR DESCRIPTION
将消息输入框的按钮吸底, 使输入框在被内容撑高时, 按钮不会被表情框遮住
修改前:
![image](https://github.com/Icalingua-plus-plus/Icalingua-plus-plus/assets/59082785/9fdbfacb-2302-4ea4-8af8-42ede073c8f8)

修改后:

![image](https://github.com/Icalingua-plus-plus/Icalingua-plus-plus/assets/59082785/715fe549-da70-4ea4-bb13-cef081723a1b)
