### PR TITLE
fix: 修复图像过长可能将消息输入框撑出可视窗口

### DIFF
--- a/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
+++ b/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
@@ -237,7 +237,9 @@
                         </slot>
                     </div>
                     <div class="vac-media-file">
-                        <img ref="mediaFile" :src="imageFile" @load="onMediaLoad" />
+                        <img ref="mediaFile" :src="imageFile" @load="onMediaLoad" :style="{
+                            'max-height': `${mediaDimensions ? `min(calc( 100vh - 120px), ${mediaDimensions.height}px)` : null}`
+                        }"/>
                     </div>
                 </div>
 
@@ -328,7 +330,7 @@
                         'vac-textarea-outline': editAndResend,
                     }"
                     :style="{
-                        'min-height': `${mediaDimensions ? mediaDimensions.height : 20}px`,
+                        'min-height': `${mediaDimensions ? `min(calc( 100vh - 120px), ${mediaDimensions.height}px)` : '20px'}`,
                         'padding-left': `${mediaDimensions ? mediaDimensions.width - 10 : 12}px`,
                     }"
                     @input="onChangeInput"
@@ -1856,7 +1858,7 @@ export default {
     display: flex;
     margin: 12px 0 10px 5px;
     align-items: flex-end;
-    
+
     svg,
     .vac-wrapper {
         margin: 0 7px;


### PR DESCRIPTION
修复这种极端情况下的功能异常
![image](https://github.com/Icalingua-plus-plus/Icalingua-plus-plus/assets/59082785/7555e493-7c4d-4731-9939-2c4df58f22fe)
