### PR TITLE
fix: 修复图像过长可能将消息输入框撑出可视窗口

### DIFF
--- a/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
+++ b/icalingua/src/renderer/components/vac-mod/ChatWindow/Room/Room.vue
@@ -237,7 +237,9 @@
                         </slot>
                     </div>
                     <div class="vac-media-file">
-                        <img ref="mediaFile" :src="imageFile" @load="onMediaLoad" />
+                        <img ref="mediaFile" :src="imageFile" @load="onMediaLoad" :style="{
+                            'max-height': `${mediaDimensions ? `min(calc( 100vh - 120px), ${mediaDimensions.height}px)` : null}`
+                        }"/>
                     </div>
                 </div>
 
@@ -328,7 +330,7 @@
                         'vac-textarea-outline': editAndResend,
                     }"
                     :style="{
-                        'min-height': `${mediaDimensions ? mediaDimensions.height : 20}px`,
+                        'min-height': `${mediaDimensions ? `min(calc( 100vh - 120px), ${mediaDimensions.height}px)` : '20px'}`,
                         'padding-left': `${mediaDimensions ? mediaDimensions.width - 10 : 12}px`,
                     }"
                     @input="onChangeInput"


### PR DESCRIPTION
修复图像过长可能将消息输入框撑出可视窗口
![image](https://github.com/Icalingua-plus-plus/Icalingua-plus-plus/assets/59082785/09ca0cc2-28ca-4e87-9f37-81ade8a36cae)
