### PR TITLE
fix(docker):Make Docker image smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,16 @@ RUN npm i pnpm -g
 RUN cd icalingua-bridge-oicq && \ 
     pnpm i && \
     pnpm compile
+ENV NODE_ENV=production
+RUN mv /app/icalingua-bridge-oicq/build /tmp/build && cd /tmp/build && pnpm i
 
 # Production image, copy all the files and run next
 FROM node:18-alpine as runner
 
 WORKDIR /app
-RUN apk add ffmpeg alpine-sdk python3 py3-pip curl
-COPY --from=builder /app/icalingua-bridge-oicq ./
-RUN npm i
-COPY --from=builder /app/node_modules/@icalingua ./node_modules/@icalingua
-RUN apk del alpine-sdk python3 py3-pip
+RUN apk add ffmpeg
+COPY --from=builder /tmp/build ./build
+COPY --from=builder /app/icalingua-bridge-oicq/config.yaml ./
 ENV TZ=Asia/Shanghai
 
 EXPOSE 6789

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:18-alpine as builder
 RUN apk add make g++ alpine-sdk python3 py3-pip   
 WORKDIR  /app
 COPY . .
-RUN npm i pnpm -g 
+RUN corepack enable
 RUN cd icalingua-bridge-oicq && \ 
     pnpm i && \
     pnpm compile

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN cd icalingua-bridge-oicq && \
     pnpm i && \
     pnpm compile
 ENV NODE_ENV=production
-RUN mv /app/icalingua-bridge-oicq/build /tmp/build && cd /tmp/build && pnpm i
+RUN mv /app/icalingua-bridge-oicq/build /tmp/build && cp -f .npmrc /tmp/build/ && cd /tmp/build && pnpm i && rm -f .npmrc
 
 # Production image, copy all the files and run next
 FROM node:18-alpine as runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mv /app/icalingua-bridge-oicq/build /tmp/build && cd /tmp/build && pnpm i
 FROM node:18-alpine as runner
 
 WORKDIR /app
-RUN apk add ffmpeg
+RUN apk add ffmpeg curl
 COPY --from=builder /tmp/build ./build
 COPY --from=builder /app/icalingua-bridge-oicq/config.yaml ./
 ENV TZ=Asia/Shanghai


### PR DESCRIPTION
该pr:
减小了docker打包icalingua-bridge-oicq的镜像大小(原打包\~260mb解包\~780mb,修改后打包\~100mb解包\~300mb)

`docker run <hash> node build`确认可用, 实际效果还没测试
